### PR TITLE
Initial display of zaakbesluiten

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -60,7 +60,7 @@ pyyaml==5.1.2             # via gemma-zds-client, tablib
 raven==6.10.0             # via -r requirements/base.in
 redis==3.3.8              # via django-redis
 requests-mock==1.7.0      # via -r requirements/base.in
-requests==2.22.0          # via django-auth-adfs, django-camunda, gemma-zds-client, requests-mock
+requests==2.22.0          # via django-auth-adfs, django-camunda, gemma-zds-client, requests-mock, zgw-consumers
 rules==2.2                # via -r requirements/base.in
 six==1.12.0               # via cryptography, django-appconf, furl, isodate, orderedmultidict, python-dateutil, requests-mock
 sqlparse==0.3.0           # via django
@@ -71,5 +71,5 @@ vine==1.3.0               # via amqp, celery
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.3.0               # via aiohttp
-zgw-consumers==0.10.3     # via -r requirements/base.in
+zgw-consumers==0.12.0     # via -r requirements/base.in
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -69,7 +69,7 @@ pyyaml==5.1.2             # via -r requirements/base.txt, gemma-zds-client, tabl
 raven==6.10.0             # via -r requirements/base.txt
 redis==3.3.8              # via -r requirements/base.txt, django-redis
 requests-mock==1.7.0      # via -r requirements/base.txt, -r requirements/test-tools.in
-requests==2.22.0          # via -r requirements/base.txt, django-auth-adfs, django-camunda, gemma-zds-client, requests-mock
+requests==2.22.0          # via -r requirements/base.txt, django-auth-adfs, django-camunda, gemma-zds-client, requests-mock, zgw-consumers
 rules==2.2                # via -r requirements/base.txt
 six==1.12.0               # via -r requirements/base.txt, cryptography, django-appconf, freezegun, furl, isodate, orderedmultidict, python-dateutil, requests-mock, webtest
 soupsieve==2.0            # via beautifulsoup4
@@ -86,5 +86,5 @@ webtest==2.0.34           # via django-webtest
 xlrd==1.2.0               # via -r requirements/base.txt, tablib
 xlwt==1.3.0               # via -r requirements/base.txt, tablib
 yarl==1.3.0               # via -r requirements/base.txt, aiohttp
-zgw-consumers==0.10.3     # via -r requirements/base.txt
+zgw-consumers==0.12.0     # via -r requirements/base.txt
 zipp==0.6.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -90,7 +90,7 @@ raven==6.10.0             # via -r requirements/ci.txt
 redis==3.3.8              # via -r requirements/ci.txt, django-redis
 regex==2020.2.20          # via black
 requests-mock==1.7.0      # via -r requirements/ci.txt, ddt-api-calls
-requests==2.22.0          # via -r requirements/ci.txt, ddt-api-calls, django-auth-adfs, django-camunda, gemma-zds-client, requests-mock, sphinx
+requests==2.22.0          # via -r requirements/ci.txt, ddt-api-calls, django-auth-adfs, django-camunda, gemma-zds-client, requests-mock, sphinx, zgw-consumers
 rules==2.2                # via -r requirements/ci.txt
 six==1.12.0               # via -r requirements/ci.txt, cryptography, django-appconf, django-extensions, freezegun, furl, isodate, orderedmultidict, packaging, pip-tools, python-dateutil, requests-mock, webtest
 snowballstemmer==2.0.0    # via sphinx
@@ -119,7 +119,7 @@ webtest==2.0.34           # via -r requirements/ci.txt, django-webtest
 xlrd==1.2.0               # via -r requirements/ci.txt, tablib
 xlwt==1.3.0               # via -r requirements/ci.txt, tablib
 yarl==1.3.0               # via -r requirements/ci.txt, aiohttp
-zgw-consumers==0.10.3     # via -r requirements/ci.txt
+zgw-consumers==0.12.0     # via -r requirements/ci.txt
 zipp==0.6.0               # via -r requirements/ci.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/zac/core/templates/core/zaak_besluiten.html
+++ b/src/zac/core/templates/core/zaak_besluiten.html
@@ -33,7 +33,7 @@
                 </tr>
             </thead>
             <tbody>
-                {% for besluite in besluiten %}
+                {% for besluit in besluiten %}
                     <tr>
                         <th class="table__id-column">{{ besluit.identificatie }}</th>
                         <td>{{ besluit.besluittype.omschrijving }}</td>

--- a/src/zac/core/templates/core/zaak_besluiten.html
+++ b/src/zac/core/templates/core/zaak_besluiten.html
@@ -1,0 +1,50 @@
+{% extends "core/zaak_detail.html" %}
+{% load i18n sniplates rules %}
+
+
+{% block content %}
+
+<a href="{% url 'core:zaak-detail' bronorganisatie=zaak.bronorganisatie identificatie=zaak.identificatie %}" class="link link--backlink">
+    Terug naar de zaakgegevens
+</a>
+
+<header class="zaak-detail-page__header">
+
+    <h1 class="page-title" title="Zaaktype">
+        Besluiten voor "{{ zaak.zaaktype.omschrijving }}"-zaak
+        <br>
+        <small class="page-title__extra" title="Zaaktype">
+            {{ zaak.omschrijving }}
+        </small>
+    </h1>
+
+</header>
+
+<article class="zaak-detail">
+    <section class="zaak-detail__panel zaak-detail__panel--full content-panel">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th class="table__header">Identificatie</th>
+                    <th class="table__header">Type</th>
+                    <th class="table__header">Beslisdatum</th>
+                    <th class="table__header">Ingangsdatum</th>
+                    <th class="table__header">Toelichting</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for besluite in besluiten %}
+                    <tr>
+                        <th class="table__id-column">{{ besluit.identificatie }}</th>
+                        <td>{{ besluit.besluittype.omschrijving }}</td>
+                        <td>{{ besluit.datum|date:"j F, Y" }}</td>
+                        <td>{{ besluit.ingangsdatum|date:"j F, Y" }}</td>
+                        <td>{{ besluit.toelichting|default:"-" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+</article>
+
+{% endblock content %}

--- a/src/zac/core/templates/core/zaak_detail.html
+++ b/src/zac/core/templates/core/zaak_detail.html
@@ -20,6 +20,16 @@
         <strong>{{ zaak.get_vertrouwelijkheidaanduiding_display }}</strong>
     </p>
 </article>
+
+{% block nav-main-id-subnav %}
+<nav class="object-id-nav">
+    <ul class="nav-menu nav-menu--object-id">
+        {% nav_menu_item 'core:zaak-activiteiten' _("Activiteiten") bronorganisatie=zaak.bronorganisatie identificatie=zaak.identificatie %}
+        {% nav_menu_item 'core:zaak-besluiten' _("Besluiten") bronorganisatie=zaak.bronorganisatie identificatie=zaak.identificatie %}
+    </ul>
+</nav>
+{% endblock %}
+
 {% endblock %}
 
 

--- a/src/zac/core/urls.py
+++ b/src/zac/core/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path
 
+from .views.besluiten import ZaakBesluitenView
 from .views.cache import FlushCacheView
 from .views.documents import DownloadDocumentView
 from .views.processes import (
@@ -36,6 +37,11 @@ urlpatterns = [
                     "<bronorganisatie>/<identificatie>/activiteiten/",
                     ZaakActiviteitenView.as_view(),
                     name="zaak-activiteiten",
+                ),
+                path(
+                    "<bronorganisatie>/<identificatie>/besluiten/",
+                    ZaakBesluitenView.as_view(),
+                    name="zaak-besluiten",
                 ),
                 path(
                     "<bronorganisatie>/<identificatie>/afhandelen/",

--- a/src/zac/core/views/besluiten.py
+++ b/src/zac/core/views/besluiten.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict
+
 from zac.accounts.mixins import PermissionRequiredMixin
 
 from ..base_views import BaseDetailView
 from ..permissions import zaken_inzien
-from ..services import find_zaak
+from ..services import find_zaak, get_besluiten
 
 
 class ZaakBesluitenView(PermissionRequiredMixin, BaseDetailView):
@@ -14,3 +16,12 @@ class ZaakBesluitenView(PermissionRequiredMixin, BaseDetailView):
         zaak = find_zaak(**self.kwargs)
         self.check_object_permissions(zaak)
         return zaak
+
+    def get_context_data(self, **kwargs) -> Dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "besluiten": get_besluiten(self.object),
+            }
+        )
+        return context

--- a/src/zac/core/views/besluiten.py
+++ b/src/zac/core/views/besluiten.py
@@ -1,0 +1,16 @@
+from zac.accounts.mixins import PermissionRequiredMixin
+
+from ..base_views import BaseDetailView
+from ..permissions import zaken_inzien
+from ..services import find_zaak
+
+
+class ZaakBesluitenView(PermissionRequiredMixin, BaseDetailView):
+    template_name = "core/zaak_besluiten.html"
+    context_object_name = "zaak"
+    permission_required = zaken_inzien.name
+
+    def get_object(self):
+        zaak = find_zaak(**self.kwargs)
+        self.check_object_permissions(zaak)
+        return zaak

--- a/src/zac/sass/components/_all.scss
+++ b/src/zac/sass/components/_all.scss
@@ -14,6 +14,7 @@
 @import "nav-panel";
 
 @import "nav-menu";
+@import "object-id-nav";
 @import "footer";
 
 @import "page-controls";

--- a/src/zac/sass/components/_nav-menu.scss
+++ b/src/zac/sass/components/_nav-menu.scss
@@ -1,3 +1,4 @@
+@import "../lib/bem";
 @import "../lib/colors";
 
 $nav-menu__item-color: $color-primary !default;
@@ -9,22 +10,51 @@ $nav-menu__item-background-color--hover: $color-primary !default;
   list-style-type: none;
   font-size: 1.2rem;
 
-  & &__item {
+  @include modifier('object-id') {
+    padding-left: 1em;
+    font-size: 1.05rem;
+
+    @include element('item') {
+      @include modifier('active') {
+        border-left-color: rgba($color-highlight, 0.3);
+      }
+
+      &:hover {
+        border-left-color: $color-highlight;
+      }
+    }
+
+    @include element('item-link') {
+      color: lighten($color-text, 15%);
+      padding: 0.5rem 0.4rem;
+
+      &:before {
+        content: "> ";
+        color: lighten($color-text, 40%);
+      }
+    }
+  }
+
+  @include element('item') {
     border-bottom: solid 1px #eee;
     border-left: solid 4px transparent;
     transition: all 0.2s ease;
     margin: 0;
 
+    &:last-child {
+      border-bottom-color: transparent;
+    }
+
+    @include modifier('active') {
+      border-left-color: rgba($nav-menu__item-background-color--hover, 0.3);
+    }
+
     &:hover {
       border-left-color: $nav-menu__item-background-color--hover;
     }
-
-    &--active {
-      border-left-color: rgba($nav-menu__item-background-color--hover, 0.3);
-    }
   }
 
-  & &__item-link {
+  @include element('item-link') {
     display: block;
     padding: 1rem 0.8rem;
     color: $nav-menu__item-color;

--- a/src/zac/sass/components/_object-id-nav.scss
+++ b/src/zac/sass/components/_object-id-nav.scss
@@ -1,0 +1,8 @@
+@import "../lib/bem";
+@import "../lib/typography";
+
+.object-id-nav {
+  background: white;
+  // border-bottom: solid 2px $color-highlight;
+  // border-left: solid 4px $color-highlight;
+}


### PR DESCRIPTION
Besluit can be added through Open Zaak admin for now.

The table-display does not nearly convey all the available information - most notably the documents that hold the actual "besluit". Given the timeline, this did not make it into MVP.