### PR TITLE
Fix crash on homepage when zaak no longer exists

### DIFF
--- a/src/zac/notifications/tests/test_zaak_destroyed.py
+++ b/src/zac/notifications/tests/test_zaak_destroyed.py
@@ -1,0 +1,54 @@
+from django.urls import reverse
+from django.utils import timezone
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from zac.accounts.tests.factories import UserFactory
+from zac.activities.models import Activity, Event
+from zac.activities.tests.factories import ActivityFactory, EventFactory
+
+from .utils import BRONORGANISATIE, ZAAKTYPE
+
+NOTIFICATION = {
+    "kanaal": "zaken",
+    "hoofdObject": "https://some.zrc.nl/api/v1/zaken/f3ff2713-2f53-42ff-a154-16842309ad60",
+    "resource": "zaak",
+    "resourceUrl": "https://some.zrc.nl/api/v1/zaken/f3ff2713-2f53-42ff-a154-16842309ad60",
+    "actie": "destroy",
+    "aanmaakdatum": timezone.now().isoformat(),
+    "kenmerken": {
+        "bronorganisatie": BRONORGANISATIE,
+        "zaaktype": ZAAKTYPE,
+        "vertrouwelijkheidaanduiding": "geheim",
+    },
+}
+
+
+class ZaakDestroyedTests(APITestCase):
+    """
+    Test that the appropriate actions happen on zaak-destroyed notifications.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create(username="notifs")
+
+    def setUp(self):
+        super().setUp()
+
+        self.client.force_authenticate(user=self.user)
+
+    def test_ad_hoc_activities_deleted(self):
+        path = reverse("notifications:callback")
+
+        activity = ActivityFactory.create(
+            zaak="https://some.zrc.nl/api/v1/zaken/f3ff2713-2f53-42ff-a154-16842309ad60"
+        )
+        EventFactory.create(activity=activity)
+
+        response = self.client.post(path, NOTIFICATION)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Activity.objects.exists())
+        self.assertFalse(Event.objects.exists())

--- a/src/zac/notifications/views.py
+++ b/src/zac/notifications/views.py
@@ -4,6 +4,7 @@ from rest_framework.views import APIView
 from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.zaken import Zaak
 
+from zac.activities.models import Activity
 from zac.core.cache import invalidate_zaak_cache, invalidate_zaak_list_cache
 from zac.core.services import _client_from_url
 
@@ -26,7 +27,7 @@ class NotificationCallbackView(APIView):
                 self._handle_zaak_creation(data["hoofd_object"])
             elif data["actie"] in ["update", "partial_update"]:
                 self._handle_zaak_update(data["hoofd_object"])
-            elif data["actie"] == ["destroy"]:
+            elif data["actie"] == "destroy":
                 self._handle_zaak_destroy(data["hoofd_object"])
         elif (
             data["resource"] in ["resultaat", "status", "zaakeigenschap"]
@@ -50,9 +51,7 @@ class NotificationCallbackView(APIView):
         invalidate_zaak_list_cache(client, zaak)
 
     def _handle_zaak_destroy(self, zaak_url: str):
-        import bpdb
-
-        bpdb.set_trace()
+        Activity.objects.filter(zaak=zaak_url).delete()
 
     def _handle_related_creation(self, zaak_url):
         zaak = self._retrieve_zaak(zaak_url)

--- a/src/zac/notifications/views.py
+++ b/src/zac/notifications/views.py
@@ -21,13 +21,13 @@ class NotificationCallbackView(APIView):
         if not data["kanaal"] == "zaken":
             return
 
-        if data["resource"] == "zaak" and data["actie"] == "create":
-            self._handle_zaak_creation(data["hoofd_object"])
-        elif data["resource"] == "zaak" and data["actie"] in (
-            "update",
-            "partial_update",
-        ):
-            self._handle_zaak_update(data["hoofd_object"])
+        if data["resource"] == "zaak":
+            if data["actie"] == "create":
+                self._handle_zaak_creation(data["hoofd_object"])
+            elif data["actie"] in ["update", "partial_update"]:
+                self._handle_zaak_update(data["hoofd_object"])
+            elif data["actie"] == ["destroy"]:
+                self._handle_zaak_destroy(data["hoofd_object"])
         elif (
             data["resource"] in ["resultaat", "status", "zaakeigenschap"]
             and data["actie"] == "create"
@@ -48,6 +48,11 @@ class NotificationCallbackView(APIView):
         client = _client_from_url(zaak_url)
         zaak = self._retrieve_zaak(zaak_url)
         invalidate_zaak_list_cache(client, zaak)
+
+    def _handle_zaak_destroy(self, zaak_url: str):
+        import bpdb
+
+        bpdb.set_trace()
 
     def _handle_related_creation(self, zaak_url):
         zaak = self._retrieve_zaak(zaak_url)


### PR DESCRIPTION
Conditions for crash:

- Ad-hoc activities assigned to logged in user
- one or more of the activities are for a zaak that cannot be retrieved from the API anymore