### PR TITLE
Fix session affecting other generic process forms

### DIFF
--- a/src/zac/core/task_handlers.py
+++ b/src/zac/core/task_handlers.py
@@ -5,3 +5,5 @@ Define which form keys map to which handlers (urls/views).
 HANDLERS = {
     "zac:doRedirect": "core:redirect-task",
 }
+
+REVERSE_HANDLERS = {handler: form_key for form_key, handler in HANDLERS.items()}


### PR DESCRIPTION
The URL to redirect to is stored in the session, which is read by the
PerformTaskView. If you execute a redirect-task, the URL is stored
in the session. When you then don't complete the task (yet), the value
is not cleared from the session. PerformTaskView is used for non-redirect
tasks as well, which then incorrectly receives information to redirect.

This patch removes the redirect-info if the form key does not match
the redirect-type of user task, preventing any windows from being opened
or being redirect to another page.