### PR TITLE
De-clutter display of authorization profiles list

### DIFF
--- a/src/zac/accounts/templates/accounts/authorizationprofile_list.html
+++ b/src/zac/accounts/templates/accounts/authorizationprofile_list.html
@@ -39,11 +39,15 @@
                             </div>
                             <div class="permission-set__va">{{ permission_set.get_max_va_display }}</div>
                             <div class="permission-set__zaaktypen">
-                                {% for zaaktype in permission_set.zaaktypen.get_for_presentation %}
-                                    <div class="permission_set__zaaktype">
-                                        {{ zaaktype.omschrijving }}
-                                    </div>
-                                {% endfor %}
+                                {% if not permission_set.zaaktype_identificaties %}
+                                    (alle zaaktypen binnen catalogus)
+                                {% else %}
+                                    {% for zaaktype in permission_set.zaaktypen.get_for_presentation %}
+                                        <div class="permission_set__zaaktype">
+                                            {{ zaaktype.omschrijving }}
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
                             </div>
                         </div>
                     {% endfor %}


### PR DESCRIPTION
Displaying all the zaaktypen in the list-view leads to a cluttered
interface. This patch just summarizes the list to 'all zaaktypen are selected'.