### PR TITLE
Ensure that previously selected values are not reset

### DIFF
--- a/src/zac/accounts/templates/accounts/permissionset_form.html
+++ b/src/zac/accounts/templates/accounts/permissionset_form.html
@@ -1,5 +1,5 @@
 {% extends "master.html" %}
-{% load sniplates %}
+{% load i18n sniplates %}
 
 
 {% block content %}
@@ -46,7 +46,12 @@
 
     {% form_field form.informatieobjecttype_max_va %}
 
-    {% widget 'form:submit' label=_("Toevoegen") %}
+    {% if form.instance.id %}
+        {% trans "Change" as btn_label %}
+    {% else %}
+        {% trans "Add" as btn_label %}
+    {% endif %}
+    {% widget 'form:submit' label=btn_label %}
 </form>
 
 {% endblock %}

--- a/src/zac/js/components/checkbox-select-dynamic/index.js
+++ b/src/zac/js/components/checkbox-select-dynamic/index.js
@@ -25,7 +25,7 @@ const checkboxSelect = (node) => {
     const options = JSON.parse(document.getElementById(values).innerText);
     const initials = JSON.parse(document.getElementById(initial).innerText);
     const showOptions = (group, values) => {
-        const markUp = getOptionsHtml(name, options[group] || [], [values]);
+        const markUp = getOptionsHtml(name, options[group] || [], values);
         node.innerHTML = markUp;
     };
 


### PR DESCRIPTION
The bug was that a list of lists was passed to the `Set` constructor, rather than just the list of selected values to test.