### PR TITLE
Initial experiment using ES index for permission-related list queries

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -10,6 +10,7 @@ isort
 django-debug-toolbar
 ddt_api_calls
 django-extensions
+django-elasticsearch-debug-toolbar
 
 # Documentation
 sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,6 +35,7 @@ django-camunda==0.9.3     # via -r requirements/ci.txt
 django-choices==1.7.0     # via -r requirements/ci.txt, zgw-consumers
 django-compat==1.0.15     # via -r requirements/ci.txt, django-hijack, django-hijack-admin
 django-debug-toolbar==1.11  # via -r requirements/dev.in
+django-elasticsearch-debug-toolbar==2.0.0  # via -r requirements/dev.in
 django-extensions==2.1.6  # via -r requirements/dev.in
 django-extra-views==0.13.0  # via -r requirements/ci.txt
 django-filter==2.3.0      # via -r requirements/ci.txt

--- a/src/zac/conf/dev.py
+++ b/src/zac/conf/dev.py
@@ -51,7 +51,7 @@ REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += (
 
 
 # Django debug toolbar
-INSTALLED_APPS += ["debug_toolbar", "ddt_api_calls"]
+INSTALLED_APPS += ["debug_toolbar", "ddt_api_calls", "elastic_panel"]
 MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 INTERNAL_IPS = ("127.0.0.1",)
 DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}
@@ -70,6 +70,7 @@ DEBUG_TOOLBAR_PANELS = [
     "debug_toolbar.panels.redirects.RedirectsPanel",
     "debug_toolbar.panels.profiling.ProfilingPanel",
     "ddt_api_calls.panels.APICallsPanel",
+    "elastic_panel.panel.ElasticDebugPanel",
 ]
 
 AXES_BEHIND_REVERSE_PROXY = (

--- a/src/zac/core/services.py
+++ b/src/zac/core/services.py
@@ -31,6 +31,7 @@ from zgw_consumers.service import get_paginated_results
 from zac.accounts.datastructures import VA_ORDER
 from zac.accounts.permissions import UserPermissions
 from zac.contrib.brp.models import BRPConfig
+from zac.elasticsearch.searches import search
 from zac.utils.decorators import cache as cache_result
 from zgw.models import InformatieObjectType, StatusType, Zaak
 
@@ -432,9 +433,7 @@ def get_zaken_es(
     _base_zaaktypen = {zt.url: zt for zt in get_zaaktypen(user_perms)}
 
     # ES search
-    from zac.elasticsearch.searches import search
-
-    zaak_urls = search(size=25, **find_kwargs)
+    zaak_urls = search(size=50, **find_kwargs)
 
     def _get_zaak(zaak_url):
         return get_zaak(zaak_url=zaak_url)
@@ -446,14 +445,6 @@ def get_zaken_es(
     # resolve zaaktype reference
     for zaak in zaken:
         zaak.zaaktype = _base_zaaktypen[zaak.zaaktype]
-
-    # sort results by startdatum / registratiedatum / identificatie
-
-    zaken = sorted(
-        zaken,
-        key=lambda zaak: (zaak.registratiedatum, zaak.startdatum, zaak.identificatie),
-        reverse=True,
-    )
 
     return zaken
 

--- a/src/zac/core/services.py
+++ b/src/zac/core/services.py
@@ -369,6 +369,110 @@ def get_zaken(
                         }
                     )
 
+    with parallel() as executor:
+        results = executor.map(lambda kwargs: _find_zaken(**kwargs), find_kwargs)
+        flattened = sum(list(results), [])
+
+    zaken = factory(Zaak, flattened)
+
+    # resolve zaaktype reference
+    for zaak in zaken:
+        zaak.zaaktype = _base_zaaktypen[zaak.zaaktype]
+
+    # sort results by startdatum / registratiedatum / identificatie
+
+    zaken = sorted(
+        zaken,
+        key=lambda zaak: (zaak.registratiedatum, zaak.startdatum, zaak.identificatie),
+        reverse=True,
+    )
+
+    return zaken
+
+
+def get_zaken_es(
+    user_perms: UserPermissions,
+    zaaktypen: List[str] = None,
+    identificatie: str = "",
+    bronorganisatie: str = "",
+    find_all=False,
+    **query_params,
+) -> List[Zaak]:
+    """
+    Fetch all zaken from the ZRCs.
+
+    Only retrieve what the user permissions dictate.
+    """
+    _base_zaaktypen = {zt.url: zt for zt in get_zaaktypen(user_perms)}
+    allowed_zaaktypen = _base_zaaktypen
+
+    if user_perms.user.is_superuser:
+        query_zaaktypen = zaaktypen or [""]
+    else:
+        query_zaaktypen = (
+            allowed_zaaktypen.keys()
+            if not zaaktypen
+            else set(zaaktypen).intersection(set(allowed_zaaktypen))
+        )
+
+    # build keyword arguments for retrieval jobs - running network calls in parallel
+    # if possible
+    find_kwargs = []
+    zrcs = Service.objects.filter(api_type=APITypes.zrc)
+    for zrc in zrcs:
+        client = zrc.build_client()
+
+        for zaaktype_url in query_zaaktypen:
+            # figure out the max va
+            relevant_perms = [
+                perm
+                for perm in user_perms.zaaktype_permissions
+                if perm.permission == zaken_inzien.name and perm.contains(zaaktype_url)
+            ]
+
+            if not relevant_perms and not user_perms.user.is_superuser:
+                continue
+
+            # sort them by max va
+            relevant_perms = sorted(
+                relevant_perms, key=lambda ztp: VA_ORDER[ztp.max_va], reverse=True
+            )
+            max_va = relevant_perms[0].max_va if relevant_perms else ""
+            if user_perms.user.is_superuser:
+                relevant_oos = {None}
+            else:
+                relevant_oos = {perm.oo for perm in relevant_perms}
+
+            base_find_kwargs = {
+                "client": client,
+                "identificatie": identificatie,
+                "bronorganisatie": bronorganisatie,
+                "zaaktype": zaaktype_url,
+                "max_va": max_va,
+                "find_all": find_all,
+            }
+
+            # check if we need to filter on OO
+            if (
+                None in relevant_oos
+            ):  # no limitation on OO because of some AP at some point
+                find_kwargs.append(
+                    {
+                        **base_find_kwargs,
+                        **query_params,
+                    }
+                )
+            else:
+                for oo_slug in relevant_oos:
+                    find_kwargs.append(
+                        {
+                            **base_find_kwargs,
+                            "rol__betrokkeneType": "organisatorische_eenheid",
+                            "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie": oo_slug,
+                            **query_params,
+                        }
+                    )
+
     # ES search
     from zac.elasticsearch.searches import search
 

--- a/src/zac/core/services.py
+++ b/src/zac/core/services.py
@@ -401,7 +401,11 @@ def get_allowed_kwargs(user_perms: UserPermissions) -> list:
     ]
 
     find_kwargs = [
-        {"zaaktypen": perm.zaaktypen, "max_va": perm.max_va, "oo": perm.oo}
+        {
+            "zaaktypen": [zaaktype.url for zaaktype in perm.zaaktypen],
+            "max_va": perm.max_va,
+            "oo": perm.oo,
+        }
         for perm in relevant_perms
     ]
 

--- a/src/zac/core/services.py
+++ b/src/zac/core/services.py
@@ -369,6 +369,26 @@ def get_zaken(
                         }
                     )
 
+    from zac.elasticsearch.searches import search
+
+    results = search(
+        size=25,
+        identificatie=identificatie,
+        bronorganisatie=bronorganisatie,
+        filters=[
+            {
+                "zaaktype": find_kwarg_dict["zaaktype"],
+                "max_va": find_kwarg_dict["max_va"],
+                "oo": find_kwarg_dict[
+                    "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie"
+                ],
+            }
+            for find_kwarg_dict in find_kwargs
+        ],
+    )
+
+    # TODO: use result document URLs
+
     with parallel() as executor:
         results = executor.map(lambda kwargs: _find_zaken(**kwargs), find_kwargs)
         flattened = sum(list(results), [])

--- a/src/zac/core/services.py
+++ b/src/zac/core/services.py
@@ -390,110 +390,50 @@ def get_zaken(
     return zaken
 
 
+def get_allowed_kwargs(user_perms: UserPermissions) -> list:
+    if user_perms.user.is_superuser:
+        return []
+
+    relevant_perms = [
+        perm
+        for perm in user_perms.zaaktype_permissions
+        if perm.permission == zaken_inzien.name
+    ]
+
+    find_kwargs = [
+        {"zaaktypen": perm.zaaktypen, "max_va": perm.max_va, "oo": perm.oo}
+        for perm in relevant_perms
+    ]
+
+    return find_kwargs
+
+
 def get_zaken_es(
     user_perms: UserPermissions,
-    zaaktypen: List[str] = None,
-    identificatie: str = "",
-    bronorganisatie: str = "",
-    find_all=False,
-    **query_params,
+    query_params=None,
 ) -> List[Zaak]:
     """
     Fetch all zaken from the ZRCs.
 
-    Only retrieve what the user permissions dictate.
+    Only retrieve what the user is allowed to see.
     """
+    # todo validate query_params
+    find_kwargs = query_params or {}
+    allowed_kwargs = get_allowed_kwargs(user_perms)
+    if not user_perms.user.is_superuser and not allowed_kwargs:
+        return []
+
+    find_kwargs["allowed"] = allowed_kwargs
+
     _base_zaaktypen = {zt.url: zt for zt in get_zaaktypen(user_perms)}
-    allowed_zaaktypen = _base_zaaktypen
-
-    if user_perms.user.is_superuser:
-        query_zaaktypen = zaaktypen or [""]
-    else:
-        query_zaaktypen = (
-            allowed_zaaktypen.keys()
-            if not zaaktypen
-            else set(zaaktypen).intersection(set(allowed_zaaktypen))
-        )
-
-    # build keyword arguments for retrieval jobs - running network calls in parallel
-    # if possible
-    find_kwargs = []
-    zrcs = Service.objects.filter(api_type=APITypes.zrc)
-    for zrc in zrcs:
-        client = zrc.build_client()
-
-        for zaaktype_url in query_zaaktypen:
-            # figure out the max va
-            relevant_perms = [
-                perm
-                for perm in user_perms.zaaktype_permissions
-                if perm.permission == zaken_inzien.name and perm.contains(zaaktype_url)
-            ]
-
-            if not relevant_perms and not user_perms.user.is_superuser:
-                continue
-
-            # sort them by max va
-            relevant_perms = sorted(
-                relevant_perms, key=lambda ztp: VA_ORDER[ztp.max_va], reverse=True
-            )
-            max_va = relevant_perms[0].max_va if relevant_perms else ""
-            if user_perms.user.is_superuser:
-                relevant_oos = {None}
-            else:
-                relevant_oos = {perm.oo for perm in relevant_perms}
-
-            base_find_kwargs = {
-                "client": client,
-                "identificatie": identificatie,
-                "bronorganisatie": bronorganisatie,
-                "zaaktype": zaaktype_url,
-                "max_va": max_va,
-                "find_all": find_all,
-            }
-
-            # check if we need to filter on OO
-            if (
-                None in relevant_oos
-            ):  # no limitation on OO because of some AP at some point
-                find_kwargs.append(
-                    {
-                        **base_find_kwargs,
-                        **query_params,
-                    }
-                )
-            else:
-                for oo_slug in relevant_oos:
-                    find_kwargs.append(
-                        {
-                            **base_find_kwargs,
-                            "rol__betrokkeneType": "organisatorische_eenheid",
-                            "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie": oo_slug,
-                            **query_params,
-                        }
-                    )
 
     # ES search
     from zac.elasticsearch.searches import search
 
-    zaak_urls = search(
-        size=25,
-        identificatie=identificatie,
-        bronorganisatie=bronorganisatie,
-        filters=[
-            {
-                "zaaktype": find_kwarg_dict["zaaktype"],
-                "max_va": find_kwarg_dict["max_va"],
-                "oo": find_kwarg_dict.get(
-                    "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie"
-                ),
-            }
-            for find_kwarg_dict in find_kwargs
-        ],
-    )
+    zaak_urls = search(size=25, **find_kwargs)
 
     def _get_zaak(zaak_url):
-        return get_zaak(zaak_uuid=None, zaak_url=zaak_url, client=client)
+        return get_zaak(zaak_url=zaak_url)
 
     with parallel(max_workers=10) as executor:
         results = executor.map(_get_zaak, zaak_urls)

--- a/src/zac/core/views/zaken.py
+++ b/src/zac/core/views/zaken.py
@@ -49,6 +49,7 @@ from ..services import (
     get_zaakobjecten,
     get_zaaktypen,
     get_zaken,
+    get_zaken_es,
 )
 from ..zaakobjecten import GROUPS, ZaakObjectGroup
 from .utils import filter_documenten_for_permissions, get_zaak_from_query
@@ -81,7 +82,7 @@ class Index(PermissionRequiredMixin, BaseListView):
         else:
             filters = {}
         user_perms = UserPermissions(self.request.user)
-        zaken = get_zaken(user_perms, **filters)[:50]
+        zaken = get_zaken_es(user_perms, **filters)[:50]
 
         return zaken
 

--- a/src/zac/core/views/zaken.py
+++ b/src/zac/core/views/zaken.py
@@ -48,7 +48,6 @@ from ..services import (
     get_zaak_eigenschappen,
     get_zaakobjecten,
     get_zaaktypen,
-    get_zaken,
     get_zaken_es,
 )
 from ..zaakobjecten import GROUPS, ZaakObjectGroup
@@ -82,7 +81,7 @@ class Index(PermissionRequiredMixin, BaseListView):
         else:
             filters = {}
         user_perms = UserPermissions(self.request.user)
-        zaken = get_zaken_es(user_perms, **filters)[:50]
+        zaken = get_zaken_es(user_perms, query_params=filters)[:50]
 
         return zaken
 

--- a/src/zac/elasticsearch/api.py
+++ b/src/zac/elasticsearch/api.py
@@ -31,6 +31,8 @@ def create_zaak_document(zaak: Zaak) -> ZaakDocument:
         va_order=VertrouwelijkheidsAanduidingen.get_choice(
             zaak.vertrouwelijkheidaanduiding
         ).order,
+        startdatum=zaak.startdatum,
+        registratiedatum=zaak.registratiedatum,
     )
     zaak_document.save()
     # TODO check rollen in case of update
@@ -56,6 +58,8 @@ def update_zaak_document(zaak: Zaak) -> ZaakDocument:
         va_order=VertrouwelijkheidsAanduidingen.get_choice(
             zaak.vertrouwelijkheidaanduiding
         ).order,
+        startdatum=zaak.startdatum,
+        registratiedatum=zaak.registratiedatum,
     )
     return zaak_document
 

--- a/src/zac/elasticsearch/documents.py
+++ b/src/zac/elasticsearch/documents.py
@@ -20,5 +20,8 @@ class ZaakDocument(Document):
     va_order = field.Integer()
     rollen = Nested(RolDocument)
 
+    startdatum = field.Date()
+    registratiedatum = field.Date()
+
     class Index:
         name = settings.ES_INDEX_ZAKEN

--- a/src/zac/elasticsearch/searches.py
+++ b/src/zac/elasticsearch/searches.py
@@ -66,7 +66,7 @@ def search(
         combined = Q("match_all")
 
         if filter["zaaktypen"]:
-            combined = combined & Terms(zaaktype=filter["zaaktype"])
+            combined = combined & Terms(zaaktype=filter["zaaktypen"])
 
         if filter["max_va"]:
             max_va_order = VertrouwelijkheidsAanduidingen.get_choice(

--- a/src/zac/elasticsearch/searches.py
+++ b/src/zac/elasticsearch/searches.py
@@ -60,11 +60,19 @@ def search(
 
     _filters = []
     for filter in filters:
-        max_va_order = VertrouwelijkheidsAanduidingen.get_choice(filter["max_va"]).order
-        combined = (
-            Term(zaaktype=filter["zaaktype"])
-            & Range(va_order={"lte": max_va_order})
-            & Nested(
+        combined = Q("match_all")
+
+        if filter["zaaktype"]:
+            combined = combined & Term(zaaktype=filter["zaaktype"])
+
+        if filter["max_va"]:
+            max_va_order = VertrouwelijkheidsAanduidingen.get_choice(
+                filter["max_va"]
+            ).order
+            combined = combined & Range(va_order={"lte": max_va_order})
+
+        if filter["oo"]:
+            combined = combined & Nested(
                 path="rollen",
                 query=Bool(
                     filter=[
@@ -75,7 +83,7 @@ def search(
                     ]
                 ),
             )
-        )
+
         _filters.append(combined)
 
     if _filters:

--- a/src/zac/elasticsearch/searches.py
+++ b/src/zac/elasticsearch/searches.py
@@ -50,7 +50,7 @@ def search(
     identificatie=None,
     bronorganisatie=None,
     zaaktypen=None,
-    allowed=None,
+    allowed=(),
 ):
     s = ZaakDocument.search()[:size]
 

--- a/src/zac/elasticsearch/searches.py
+++ b/src/zac/elasticsearch/searches.py
@@ -51,6 +51,7 @@ def search(
     bronorganisatie=None,
     zaaktypen=None,
     allowed=(),
+    ordering=("-identificatie", "-startdatum", "-registratiedatum"),
 ):
     s = ZaakDocument.search()[:size]
 
@@ -92,6 +93,9 @@ def search(
     if _filters:
         combined_filter = reduce(operator.or_, _filters)
         s = s.filter(combined_filter)
+
+    if ordering:
+        s = s.sort(*ordering)
 
     response = s.execute()
     zaak_urls = [hit.url for hit in response]

--- a/src/zac/elasticsearch/tests/utils.py
+++ b/src/zac/elasticsearch/tests/utils.py
@@ -1,12 +1,17 @@
 from django.conf import settings
 
 from elasticsearch_dsl import Index
+from zgw_consumers.api_models.base import factory
 
+from zac.core.rollen import Rol
+from zgw.models.zrc import Zaak
+
+from ..api import append_rol_to_document, create_zaak_document
 from ..documents import ZaakDocument
 
 
 class ESMixin:
-    def _clear_index(self):
+    def clear_index(self):
         zaken = Index(settings.ES_INDEX_ZAKEN)
         zaken.delete(ignore=404)
         ZaakDocument.init()
@@ -15,7 +20,17 @@ class ESMixin:
         zaken = Index(settings.ES_INDEX_ZAKEN)
         zaken.refresh()
 
+    def create_zaak_document(self, zaak):
+        if not isinstance(zaak, Zaak):
+            zaak = factory(Zaak, zaak)
+        create_zaak_document(zaak)
+
+    def add_rol_to_document(self, rol):
+        if not isinstance(rol, Rol):
+            rol = factory(Rol, rol)
+        append_rol_to_document(rol)
+
     def setUp(self):
         super().setUp()
 
-        self._clear_index()
+        self.clear_index()


### PR DESCRIPTION
Related issue: https://github.com/GemeenteUtrecht/ZGW/issues/551

Changes:

* "Alle zaken" are queried using ES
* `get_zaken` function is refactored: query params from the filter form and filters based on permissions are separated. 

Todo (in the next PRs since we try to keep PRs small):
* use ES for querying zaken in the dashboard
* validate filter params before usin them in `get_zaken`, because it couldn't use some arbitrary parameters anymore