### PR TITLE
Aanpassen weergave Betrokkene

### DIFF
--- a/src/zac/core/rollen.py
+++ b/src/zac/core/rollen.py
@@ -37,6 +37,12 @@ class Rol(_Rol):
 
         return getter(self)
 
+    def get_roltype_omschrijving(self) -> Optional[str]:
+        from zac.core.services import get_roltype
+
+        roltype = get_roltype(self.roltype)
+        return roltype.omschrijving
+
 
 def get_bsn(rol: Rol) -> str:
     if rol.betrokkene:

--- a/src/zac/core/services.py
+++ b/src/zac/core/services.py
@@ -195,6 +195,13 @@ def get_eigenschappen(zaaktype: ZaakType) -> List[Eigenschap]:
     return eigenschappen
 
 
+@cache_result("roltype:{url}", timeout=A_DAY)
+def get_roltype(url: str) -> RolType:
+    client = _client_from_url(url)
+    result = client.retrieve("roltype", url)
+    return factory(RolType, result)
+
+
 @cache_result("zt:roltypen:{zaaktype.url}:{omschrijving_generiek}", timeout=A_DAY)
 def get_roltypen(zaaktype: ZaakType, omschrijving_generiek: str = "") -> list:
     query_params = {"zaaktype": zaaktype.url}

--- a/src/zac/core/templates/core/zaak_detail.html
+++ b/src/zac/core/templates/core/zaak_detail.html
@@ -123,7 +123,7 @@
                 <div class="betrokkene-data"
                     data-system-type="{{ rol.betrokkene_type }}"
                     data-type="{{ rol.get_betrokkene_type_display }}"
-                    data-role="{{ rol.get_omschrijving_generiek_display }}"
+                    data-role="{{ rol.get_roltype_omschrijving }}"
                     data-name="{{ name }}"
                     data-identification="{{ rol.get_identificatie|default:'' }}"
                 >

--- a/src/zac/core/templates/core/zaak_detail.html
+++ b/src/zac/core/templates/core/zaak_detail.html
@@ -121,7 +121,7 @@
         {% for rol in rollen %}
             {% with rol.get_name|default:'' as name %}
                 <div class="betrokkene-data"
-                    data-system-type="{{ rol.betrokken_type }}"
+                    data-system-type="{{ rol.betrokkene_type }}"
                     data-type="{{ rol.get_betrokkene_type_display }}"
                     data-role="{{ rol.get_omschrijving_generiek_display }}"
                     data-name="{{ name }}"


### PR DESCRIPTION
Fixes https://github.com/GemeenteUtrecht/ZGW/issues/597

The 'Rol' column in the Betrokkene table now shows the `roltype.omschrijving` instead of the `rol.omschrijving_generiek`.