### PR TITLE
Don't create dynamic mappings for betrokkene_identificatie

### DIFF
--- a/src/zac/elasticsearch/documents.py
+++ b/src/zac/elasticsearch/documents.py
@@ -7,7 +7,8 @@ class RolDocument(InnerDoc):
     url = field.Keyword()
     betrokkene_type = field.Keyword()
     betrokkene_identificatie = field.Object(
-        properties={"identificatie": field.Keyword()}
+        properties={"identificatie": field.Keyword()},
+        dynamic=False,
     )
 
 

--- a/src/zac/elasticsearch/tests/test_index_zaken.py
+++ b/src/zac/elasticsearch/tests/test_index_zaken.py
@@ -155,3 +155,87 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, TestCase):
 
         self.assertEqual(rollen[0]["url"], rol1["url"])
         self.assertEqual(rollen[1]["url"], rol2["url"])
+
+    def test_zaken_with_different_rollen(self, m):
+        # mock API requests
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        zaaktype = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=f"{CATALOGI_ROOT}zaaktypen/a8c8bc90-defa-4548-bacd-793874c013aa",
+        )
+        zaak = generate_oas_component(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{ZAKEN_ROOT}zaken/69e98129-1f0d-497f-bbfb-84b88137edbc",
+            zaaktype=zaaktype["url"],
+            bronorganisatie="002220647",
+            identificatie="ZAAK1",
+            vertrouwelijkheidaanduiding="zaakvertrouwelijk",
+        )
+        # can't use generate_oas_component because of polymorphism
+        rol1 = {
+            "url": f"{ZAKEN_ROOT}rollen/b80022cf-6084-4cf6-932b-799effdcdb26",
+            "zaak": zaak["url"],
+            "betrokkene": None,
+            "betrokkeneType": "natuurlijk_persoon",
+            "roltype": f"{CATALOGI_ROOT}roltypen/bfd62804-f46c-42e7-a31c-4139b4c661ac",
+            "omschrijving": "zaak behandelaar",
+            "omschrijvingGeneriek": "behandelaar",
+            "roltoelichting": "some description",
+            "registratiedatum": "2020-09-01T00:00:00Z",
+            "indicatieMachtiging": "",
+            "betrokkeneIdentificatie": {
+                "geboortedatum": "2020-01-01",
+            },
+        }
+        rol2 = {
+            "url": f"{ZAKEN_ROOT}rollen/de7039d7-242a-4186-91c3-c3b49228211a",
+            "zaak": zaak["url"],
+            "betrokkene": None,
+            "betrokkeneType": "natuurlijk_persoon",
+            "roltype": f"{CATALOGI_ROOT}roltypen/bfd62804-f46c-42e7-a31c-4139b4c661ac",
+            "omschrijving": "zaak behandelaar",
+            "omschrijvingGeneriek": "behandelaar",
+            "roltoelichting": "other description",
+            "registratiedatum": "2020-09-01T00:00:00Z",
+            "indicatieMachtiging": "",
+            "betrokkeneIdentificatie": {
+                "geboortedatum": "",
+            },
+        }
+
+        m.get(
+            f"{CATALOGI_ROOT}zaaktypen",
+            json={
+                "count": 1,
+                "previous": None,
+                "next": None,
+                "results": [zaaktype],
+            },
+        )
+        m.get(
+            f"{ZAKEN_ROOT}zaken",
+            json={"count": 1, "previous": None, "next": None, "results": [zaak]},
+        )
+        m.get(
+            f"{ZAKEN_ROOT}rollen",
+            json={"count": 1, "previous": None, "next": None, "results": [rol1, rol2]},
+        )
+
+        call_command("index_zaken")
+
+        # check zaak_document exists
+        zaak_document = ZaakDocument.get(id="69e98129-1f0d-497f-bbfb-84b88137edbc")
+
+        self.assertEqual(zaak_document.identificatie, "ZAAK1")
+        self.assertEqual(zaak_document.bronorganisatie, "002220647")
+        self.assertEqual(zaak_document.zaaktype, zaaktype["url"])
+        self.assertEqual(zaak_document.va_order, 18)
+        self.assertEqual(len(zaak_document.rollen), 2)
+
+        rollen = zaak_document.rollen
+
+        self.assertEqual(rollen[0]["url"], rol1["url"])
+        self.assertEqual(rollen[1]["url"], rol2["url"])


### PR DESCRIPTION
This is a polymorphic resources, leading to errors when the first data seen is a date object,
but later data suddenly has another type (observed with empty string).