### PR TITLE
Slightly more robus handling of incomplete zaak-data

### DIFF
--- a/src/zac/core/services.py
+++ b/src/zac/core/services.py
@@ -575,7 +575,9 @@ def get_statussen(zaak: Zaak) -> List[Status]:
 
 
 @cache_result("zaak-status:{zaak.status}", timeout=AN_HOUR)
-def get_status(zaak: Zaak) -> Status:
+def get_status(zaak: Zaak) -> Optional[Status]:
+    if not zaak.status:
+        return None
     assert isinstance(zaak.status, str), "Status already resolved."
     client = _client_from_object(zaak)
     _status = client.retrieve("status", url=zaak.status)


### PR DESCRIPTION
A Zaak must have an initial status, but because of bugs in the process
it can occur this is not the case. If the status is empty, we now return
None.