### PR TITLE
109 - Create Zaken relations from zaak-detail page

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -77,5 +77,5 @@ vine==1.3.0               # via amqp, celery
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.3.0               # via aiohttp
-zgw-consumers==0.12.2     # via -r requirements/base.in
+zgw-consumers==0.13.0     # via -r requirements/base.in
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -92,5 +92,5 @@ webtest==2.0.34           # via django-webtest
 xlrd==1.2.0               # via -r requirements/base.txt, tablib
 xlwt==1.3.0               # via -r requirements/base.txt, tablib
 yarl==1.3.0               # via -r requirements/base.txt, aiohttp
-zgw-consumers==0.12.2     # via -r requirements/base.txt
+zgw-consumers==0.13.0     # via -r requirements/base.txt
 zipp==0.6.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -126,7 +126,7 @@ webtest==2.0.34           # via -r requirements/ci.txt, django-webtest
 xlrd==1.2.0               # via -r requirements/ci.txt, tablib
 xlwt==1.3.0               # via -r requirements/ci.txt, tablib
 yarl==1.3.0               # via -r requirements/ci.txt, aiohttp
-zgw-consumers==0.12.2     # via -r requirements/ci.txt
+zgw-consumers==0.13.0     # via -r requirements/ci.txt
 zipp==0.6.0               # via -r requirements/ci.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/zac/core/api/permissions.py
+++ b/src/zac/core/api/permissions.py
@@ -45,13 +45,12 @@ class CanAddRelations(permissions.BasePermission):
         if not serializer.is_valid():
             return True
 
-        # Check that the user has access to both zaken being related
+        # Check that the user has access to the main zaak
         try:
-            get_zaak(zaak_url=serializer.validated_data["main_zaak"])
-            get_zaak(zaak_url=serializer.validated_data["relation_zaak"])
+            main_zaak = get_zaak(zaak_url=serializer.validated_data["main_zaak"])
         except ClientError:
             logger.info("Invalid Zaak specified", exc_info=True)
             return False
 
-        # Check that the user has permissions to add relations
-        return request.user.has_perm(zaken_add_relations.name)
+        # Check that the user has permissions to add relations to the main zaak
+        return request.user.has_perm(zaken_add_relations.name, main_zaak)

--- a/src/zac/core/api/permissions.py
+++ b/src/zac/core/api/permissions.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 from rest_framework.views import APIView
 from zds_client import ClientError
 
-from ..permissions import zaken_add_documents
+from ..permissions import zaken_add_documents, zaken_add_relations
 from ..services import get_zaak
 
 logger = logging.getLogger(__name__)
@@ -33,3 +33,25 @@ class CanAddDocuments(permissions.BasePermission):
 
         zaak_url = serializer.validated_data["zaak"]
         return self._has_zaak_permission(request, zaak_url)
+
+
+class CanAddRelations(permissions.BasePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if request.method != "POST":
+            return False
+
+        serializer = view.get_serializer(data=request.data)
+        # if the serializer is not valid, we want to see validation errors -> permission is granted
+        if not serializer.is_valid():
+            return True
+
+        # Check that the user has access to both zaken being related
+        try:
+            get_zaak(zaak_url=serializer.validated_data["main_zaak"])
+            get_zaak(zaak_url=serializer.validated_data["relation_zaak"])
+        except ClientError:
+            logger.info("Invalid Zaak specified", exc_info=True)
+            return False
+
+        # Check that the user has permissions to add relations
+        return request.user.has_perm(zaken_add_relations.name)

--- a/src/zac/core/api/serializers.py
+++ b/src/zac/core/api/serializers.py
@@ -1,7 +1,9 @@
 from django.core.validators import RegexValidator
 from django.template.defaultfilters import filesizeformat
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
+from djchoices import ChoiceItem, DjangoChoices
 from rest_framework import serializers
 
 from .utils import (
@@ -109,3 +111,15 @@ class ExtraInfoSubjectSerializer(serializers.Serializer):
     kinderen = serializers.ListField()
     verblijfplaats = serializers.DictField()
     partners = serializers.ListField()
+
+
+class AardRelatieChoices(DjangoChoices):
+    vervolg = ChoiceItem("vervolg", _("Vervolg"))
+    bijdrage = ChoiceItem("bijdrage", _("Bijdrage"))
+    onderwerp = ChoiceItem("onderwerp", _("Onderwerp"))
+
+
+class AddZaakRelationSerializer(serializers.Serializer):
+    relation_zaak = serializers.URLField(required=True)
+    aard_relatie = serializers.ChoiceField(required=True, choices=AardRelatieChoices)
+    main_zaak = serializers.URLField(required=True)

--- a/src/zac/core/api/serializers.py
+++ b/src/zac/core/api/serializers.py
@@ -3,8 +3,8 @@ from django.template.defaultfilters import filesizeformat
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
-from djchoices import ChoiceItem, DjangoChoices
 from rest_framework import serializers
+from zgw_consumers.api_models.constants import AardRelatieChoices
 
 from .utils import (
     CSMultipleChoiceField,
@@ -113,12 +113,6 @@ class ExtraInfoSubjectSerializer(serializers.Serializer):
     partners = serializers.ListField()
 
 
-class AardRelatieChoices(DjangoChoices):
-    vervolg = ChoiceItem("vervolg", _("Vervolg"))
-    bijdrage = ChoiceItem("bijdrage", _("Bijdrage"))
-    onderwerp = ChoiceItem("onderwerp", _("Onderwerp"))
-
-
 class AddZaakRelationSerializer(serializers.Serializer):
     relation_zaak = serializers.URLField(required=True)
     aard_relatie = serializers.ChoiceField(required=True, choices=AardRelatieChoices)
@@ -136,3 +130,9 @@ class AddZaakRelationSerializer(serializers.Serializer):
 
 class ZaakIdentificatieSerializer(serializers.Serializer):
     identificatie = serializers.CharField(required=True)
+
+
+class ZaakSerializer(serializers.Serializer):
+    identificatie = serializers.CharField(required=True)
+    bronorganisatie = serializers.CharField(required=True)
+    url = serializers.URLField(required=True)

--- a/src/zac/core/api/serializers.py
+++ b/src/zac/core/api/serializers.py
@@ -124,6 +124,15 @@ class AddZaakRelationSerializer(serializers.Serializer):
     aard_relatie = serializers.ChoiceField(required=True, choices=AardRelatieChoices)
     main_zaak = serializers.URLField(required=True)
 
+    def validate(self, data):
+        """Check that the main zaak and the relation are not the same"""
+
+        if data["relation_zaak"] == data["main_zaak"]:
+            raise serializers.ValidationError(
+                _("Zaken kunnen niet met zichzelf gerelateerd worden.")
+            )
+        return data
+
 
 class ZaakIdentificatieSerializer(serializers.Serializer):
     identificatie = serializers.CharField(required=True)

--- a/src/zac/core/api/serializers.py
+++ b/src/zac/core/api/serializers.py
@@ -123,3 +123,7 @@ class AddZaakRelationSerializer(serializers.Serializer):
     relation_zaak = serializers.URLField(required=True)
     aard_relatie = serializers.ChoiceField(required=True, choices=AardRelatieChoices)
     main_zaak = serializers.URLField(required=True)
+
+
+class ZaakIdentificatieSerializer(serializers.Serializer):
+    identificatie = serializers.CharField(required=True)

--- a/src/zac/core/api/tests/test_add_zaak_relations.py
+++ b/src/zac/core/api/tests/test_add_zaak_relations.py
@@ -2,21 +2,25 @@ from django.urls import reverse_lazy
 
 import requests_mock
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase, APITransactionTestCase
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 from zgw_consumers.constants import APITypes
 from zgw_consumers.models import Service
 
 from zac.accounts.tests.factories import PermissionSetFactory, UserFactory
-from zac.core.permissions import zaken_inzien
+from zac.core.permissions import zaken_add_relations, zaken_inzien
 from zac.core.tests.utils import ClearCachesMixin
 from zac.elasticsearch.tests.utils import ESMixin
-from zac.tests.utils import generate_oas_component, mock_service_oas_get
+from zac.tests.utils import (
+    generate_oas_component,
+    mock_service_oas_get,
+    paginated_response,
+)
 
 
 @requests_mock.Mocker()
-class GetZakenTests(ESMixin, ClearCachesMixin, APITestCase):
-    endpoint = reverse_lazy("core:zaken")
+class GetZakenTests(ESMixin, ClearCachesMixin, APITransactionTestCase):
+    endpoint = reverse_lazy("core:zaken-search")
 
     def test_login_required(self, m):
         response = self.client.get(self.endpoint)
@@ -165,7 +169,7 @@ class CreateZakenRelationTests(APITestCase):
         response = self.client.post(self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_valid_request(self, m):
+    def test_valid_request_no_permissions(self, m):
         user = UserFactory.create()
         self.client.force_authenticate(user)
 
@@ -186,6 +190,7 @@ class CreateZakenRelationTests(APITestCase):
             "schemas/Zaak",
             url=f"{zaak_root}zaken/8d305721-15c9-4b1a-bfac-d2cd52a318d7",
         )
+        m.get(url=relation_zaak["url"], json=relation_zaak)
 
         # Mock the update of the main zaak
         main_zaak["relevanteAndereZaken"].append(
@@ -205,7 +210,151 @@ class CreateZakenRelationTests(APITestCase):
             },
         )
 
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_valid_request_with_permissions(self, m):
+        user = UserFactory.create()
+        self.client.force_authenticate(user)
+
+        # Mock zaaktype
+        catalogus_root = "http://catalogus.nl/api/v1/"
+        catalogus_url = (
+            f"{catalogus_root}/catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
+        )
+        Service.objects.create(api_type=APITypes.ztc, api_root=catalogus_root)
+        mock_service_oas_get(m, catalogus_root, "ztc")
+
+        zaaktype = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=f"{catalogus_root}zaaktypen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            identificatie="ZT1",
+            catalogus=catalogus_url,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+
+        m.get(url=f"{catalogus_root}zaaktypen", json=paginated_response([zaaktype]))
+
+        # Mock zaak
+        zaak_root = "http://zaken.nl/api/v1/"
+
+        Service.objects.create(api_type=APITypes.zrc, api_root=zaak_root)
+        mock_service_oas_get(m, zaak_root, "zrc")
+
+        main_zaak = generate_oas_component(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{zaak_root}zaken/e3f5c6d2-0e49-4293-8428-26139f630950",
+        )
+        m.get(url=main_zaak["url"], json=main_zaak)
+
+        relation_zaak = generate_oas_component(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{zaak_root}zaken/8d305721-15c9-4b1a-bfac-d2cd52a318d7",
+        )
+        m.get(url=relation_zaak["url"], json=relation_zaak)
+
+        # Mock the update of the main zaak
+        main_zaak["relevanteAndereZaken"].append(
+            {
+                "url": relation_zaak["url"],
+                "aardRelatie": "vervolg",
+            }
+        )
+        m.patch(url=main_zaak["url"], json=main_zaak)
+
+        # Give permissions to the user
+        PermissionSetFactory.create(
+            permissions=[zaken_inzien.name, zaken_add_relations.name],
+            for_user=user,
+            zaaktype_identificaties=["ZT1"],
+            catalogus=catalogus_url,
+            max_va=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+
+        response = self.client.post(
+            self.endpoint,
+            data={
+                "relation_zaak": relation_zaak["url"],
+                "main_zaak": main_zaak["url"],
+                "aard_relatie": "vervolg",
+            },
+        )
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_valid_request_without_permissions_to_relate(self, m):
+        user = UserFactory.create()
+        self.client.force_authenticate(user)
+
+        # Mock zaaktype
+        catalogus_root = "http://catalogus.nl/api/v1/"
+        catalogus_url = (
+            f"{catalogus_root}/catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
+        )
+        Service.objects.create(api_type=APITypes.ztc, api_root=catalogus_root)
+        mock_service_oas_get(m, catalogus_root, "ztc")
+
+        zaaktype = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=f"{catalogus_root}zaaktypen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            identificatie="ZT1",
+            catalogus=catalogus_url,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+
+        m.get(url=f"{catalogus_root}zaaktypen", json=paginated_response([zaaktype]))
+
+        # Mock zaak
+        zaak_root = "http://zaken.nl/api/v1/"
+
+        Service.objects.create(api_type=APITypes.zrc, api_root=zaak_root)
+        mock_service_oas_get(m, zaak_root, "zrc")
+
+        main_zaak = generate_oas_component(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{zaak_root}zaken/e3f5c6d2-0e49-4293-8428-26139f630950",
+        )
+        m.get(url=main_zaak["url"], json=main_zaak)
+
+        relation_zaak = generate_oas_component(
+            "zrc",
+            "schemas/Zaak",
+            url=f"{zaak_root}zaken/8d305721-15c9-4b1a-bfac-d2cd52a318d7",
+        )
+        m.get(url=relation_zaak["url"], json=relation_zaak)
+
+        # Mock the update of the main zaak
+        main_zaak["relevanteAndereZaken"].append(
+            {
+                "url": relation_zaak["url"],
+                "aardRelatie": "vervolg",
+            }
+        )
+        m.patch(url=main_zaak["url"], json=main_zaak)
+
+        # Give permissions to the zaken, but not to create relations
+        PermissionSetFactory.create(
+            permissions=[zaken_inzien.name],
+            for_user=user,
+            zaaktype_identificaties=["ZT1"],
+            catalogus=catalogus_url,
+            max_va=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+
+        response = self.client.post(
+            self.endpoint,
+            data={
+                "relation_zaak": relation_zaak["url"],
+                "main_zaak": main_zaak["url"],
+                "aard_relatie": "vervolg",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_relate_zaak_to_itself(self, m):
         user = UserFactory.create()

--- a/src/zac/core/api/tests/test_add_zaak_relations.py
+++ b/src/zac/core/api/tests/test_add_zaak_relations.py
@@ -156,7 +156,7 @@ class GetZakenTests(ESMixin, ClearCachesMixin, APITransactionTestCase):
 
 
 @requests_mock.Mocker()
-class CreateZakenRelationTests(APITestCase):
+class CreateZakenRelationTests(ClearCachesMixin, APITestCase):
     endpoint = reverse_lazy("core:add-zaak-relation")
 
     def test_login_required(self, m):
@@ -219,7 +219,7 @@ class CreateZakenRelationTests(APITestCase):
         # Mock zaaktype
         catalogus_root = "http://catalogus.nl/api/v1/"
         catalogus_url = (
-            f"{catalogus_root}/catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
+            f"{catalogus_root}catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
         )
         Service.objects.create(api_type=APITypes.ztc, api_root=catalogus_root)
         mock_service_oas_get(m, catalogus_root, "ztc")
@@ -245,6 +245,8 @@ class CreateZakenRelationTests(APITestCase):
             "zrc",
             "schemas/Zaak",
             url=f"{zaak_root}zaken/e3f5c6d2-0e49-4293-8428-26139f630950",
+            zaaktype=zaaktype["url"],
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
         m.get(url=main_zaak["url"], json=main_zaak)
 
@@ -317,6 +319,8 @@ class CreateZakenRelationTests(APITestCase):
             "zrc",
             "schemas/Zaak",
             url=f"{zaak_root}zaken/e3f5c6d2-0e49-4293-8428-26139f630950",
+            zaaktype=zaaktype["url"],
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
         m.get(url=main_zaak["url"], json=main_zaak)
 

--- a/src/zac/core/api/tests/test_add_zaak_relations.py
+++ b/src/zac/core/api/tests/test_add_zaak_relations.py
@@ -96,9 +96,6 @@ class GetZakenTests(ESMixin, ClearCachesMixin, APITransactionTestCase):
             f"{catalogus_root}/catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
         )
 
-        Service.objects.create(api_type=APITypes.ztc, api_root=catalogus_root)
-        mock_service_oas_get(m, catalogus_root, "ztc")
-
         zaaktype = generate_oas_component(
             "ztc",
             "schemas/ZaakType",
@@ -108,21 +105,9 @@ class GetZakenTests(ESMixin, ClearCachesMixin, APITransactionTestCase):
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
         )
 
-        m.get(
-            url=f"{catalogus_root}zaaktypen",
-            json={
-                "count": 1,
-                "previous": None,
-                "next": None,
-                "results": [zaaktype],
-            },
-        )
-
         # Set up zaken mocks
         zaken_root = "http://zaken.nl/api/v1/"
         zaak_identificatie = "ZAAK-2020-01"
-        Service.objects.create(api_type=APITypes.zrc, api_root=zaken_root)
-        mock_service_oas_get(m, zaken_root, "zrc")
 
         zaak = generate_oas_component(
             "zrc",
@@ -134,11 +119,7 @@ class GetZakenTests(ESMixin, ClearCachesMixin, APITransactionTestCase):
         )
 
         self.create_zaak_document(zaak)
-
-        m.get(
-            url=zaak["url"],
-            json=zaak,
-        )
+        self.refresh_index()
 
         PermissionSetFactory.create(
             permissions=[zaken_inzien.name],

--- a/src/zac/core/api/urls.py
+++ b/src/zac/core/api/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     ),
     path("documents/info", GetDocumentInfoView.as_view(), name="get-document-info"),
     path("zaken_relation", AddZaakRelationView.as_view(), name="add-zaak-relation"),
-    path("zaken", GetZakenView.as_view(), name="zaken"),
+    path("zaken_search", GetZakenView.as_view(), name="zaken-search"),
     path(
         "betrokkene/info",
         PostExtraInfoSubjectView.as_view(),

--- a/src/zac/core/api/urls.py
+++ b/src/zac/core/api/urls.py
@@ -1,9 +1,11 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from .views import (
     AddDocumentView,
+    AddZaakRelationView,
     GetDocumentInfoView,
     GetInformatieObjectTypenView,
+    GetZakenView,
     PostExtraInfoSubjectView,
 )
 
@@ -19,6 +21,8 @@ urlpatterns = [
         name="add-document",
     ),
     path("documents/info", GetDocumentInfoView.as_view(), name="get-document-info"),
+    path("zaken_relation", AddZaakRelationView.as_view(), name="add-zaak-relation"),
+    path("zaken", GetZakenView.as_view(), name="zaken"),
     path(
         "betrokkene/info",
         PostExtraInfoSubjectView.as_view(),

--- a/src/zac/core/api/views.py
+++ b/src/zac/core/api/views.py
@@ -12,6 +12,7 @@ from zgw_consumers.api_models.zaken import Zaak
 from zgw_consumers.models import Service
 
 from zac.contrib.brp.api import fetch_extrainfo_np
+from zac.elasticsearch.searches import autocomplete_zaak_search
 
 from ...accounts.permissions import UserPermissions
 from ..cache import invalidate_zaak_cache
@@ -197,12 +198,8 @@ class GetZakenView(views.APIView):
     def get(self, request: Request) -> Response:
         serializer = ZaakIdentificatieSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
-
-        zaken = get_zaken_es(
-            user_perms=UserPermissions(request.user),
-            query_params={"identificatie": serializer.validated_data["identificatie"]},
+        zaken = autocomplete_zaak_search(
+            identificatie=serializer.validated_data["identificatie"]
         )
-
         zaak_serializer = ZaakSerializer(instance=zaken, many=True)
-
         return Response(data=zaak_serializer.data)

--- a/src/zac/core/permissions.py
+++ b/src/zac/core/permissions.py
@@ -45,3 +45,8 @@ zaken_handle_access = Permission(
 zaken_request_access = Permission(
     name="zaken:toegang-aanvragen", description="Toegang aanvragen voor zaken"
 )
+
+zaken_add_relations = Permission(
+    name="zaken:nieuwe-relaties-toevoegen",
+    description="Voegen relaties tussen zaken toe.",
+)

--- a/src/zac/core/permissions.py
+++ b/src/zac/core/permissions.py
@@ -48,5 +48,5 @@ zaken_request_access = Permission(
 
 zaken_add_relations = Permission(
     name="zaken:nieuwe-relaties-toevoegen",
-    description="Voegen relaties tussen zaken toe.",
+    description="Relateer andere zaken aan de (hoofd)zaak.",
 )

--- a/src/zac/core/rules.py
+++ b/src/zac/core/rules.py
@@ -16,6 +16,7 @@ from .permissions import (
     zaakproces_send_message,
     zaakproces_usertasks,
     zaken_add_documents,
+    zaken_add_relations,
     zaken_close,
     zaken_download_documents,
     zaken_handle_access,
@@ -34,6 +35,7 @@ logger = logging.getLogger(__name__)
     zaken_close,
     zaken_add_documents,
     zaken_request_access,
+    zaken_add_relations,
 )
 def _generic_zaakpermission(
     user: User, zaak: Union[dict, Zaak], permission: Permission

--- a/src/zac/core/templates/core/zaak_detail.html
+++ b/src/zac/core/templates/core/zaak_detail.html
@@ -229,7 +229,6 @@
     </section>
     {% endif %}
 
-    {% if related_zaken %}
     <section class="zaak-detail__panel zaak-detail__panel--full content-panel">
         <div class="section-title">Gerelateerde zaken ({{ related_zaken|length }})</div>
 
@@ -265,8 +264,11 @@
                 {% endfor %}
             </tbody>
         </table>
+
+        <div id="add-zaken-relation" data-zaak="{{ zaak.url }}" data-csrftoken="{{ csrf_token }}">
+        {# React managed #}
+        </div>
     </section>
-    {% endif %}
 
     <section class="zaak-detail__panel zaak-detail__panel--full content-panel">
         <div class="section-title">Gerelateerde objecten</div>

--- a/src/zac/elasticsearch/searches.py
+++ b/src/zac/elasticsearch/searches.py
@@ -3,7 +3,7 @@ from functools import reduce
 from typing import List
 
 from elasticsearch_dsl import Q
-from elasticsearch_dsl.query import Bool, Nested, Range, Term, Terms
+from elasticsearch_dsl.query import Bool, Nested, Range, Regexp, Term, Terms
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
 from .documents import ZaakDocument
@@ -90,3 +90,16 @@ def search(
     response = s.execute()
     zaak_urls = [hit.url for hit in response]
     return zaak_urls
+
+
+def autocomplete_zaak_search(identificatie: str) -> List[ZaakDocument]:
+    search = ZaakDocument.search().query(
+        Regexp(
+            identificatie={
+                "value": f".*{identificatie}.*",
+                # "case_insensitive": True,  # 7.10 feature
+            }
+        )
+    )
+    response = search.execute()
+    return response.hits

--- a/src/zac/elasticsearch/tests/utils.py
+++ b/src/zac/elasticsearch/tests/utils.py
@@ -11,10 +11,12 @@ from ..documents import ZaakDocument
 
 
 class ESMixin:
-    def clear_index(self):
+    @staticmethod
+    def clear_index(init=False):
         zaken = Index(settings.ES_INDEX_ZAKEN)
         zaken.delete(ignore=404)
-        ZaakDocument.init()
+        if init:
+            ZaakDocument.init()
 
     def refresh_index(self):
         zaken = Index(settings.ES_INDEX_ZAKEN)
@@ -33,4 +35,10 @@ class ESMixin:
     def setUp(self):
         super().setUp()
 
-        self.clear_index()
+        self.clear_index(init=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        cls.clear_index()

--- a/src/zac/js/constants.js
+++ b/src/zac/js/constants.js
@@ -9,4 +9,10 @@ const VERTROUWELIJKHEIDAANDUIDINGEN = [
     ['zeer_geheim', 'Zeer geheim'],
 ];
 
-export { VERTROUWELIJKHEIDAANDUIDINGEN };
+const AARD_RELATIES = [
+    ['vervolg', 'Vervolg'],
+    ['bijdrage', 'Bijdrage'],
+    ['onderwerp', 'Onderwerp'],
+];
+
+export { VERTROUWELIJKHEIDAANDUIDINGEN, AARD_RELATIES };

--- a/src/zac/js/views/zaak-detail/AddZaakRelation.js
+++ b/src/zac/js/views/zaak-detail/AddZaakRelation.js
@@ -1,0 +1,170 @@
+import React from 'react';
+import Modal from 'react-modal';
+import AsyncSelect from 'react-select/async';
+import {HiddenInput} from '../../components/forms/Inputs';
+import {ErrorList, SubmitRow, Wrapper} from '../../components/forms/Utils';
+import {useImmerReducer} from 'use-immer';
+import {apiCall, get} from '../../utils/fetch';
+import {Select} from '../../components/forms/Select';
+import {AARD_RELATIES} from '../../constants';
+import {Label} from '../../components/forms/Label';
+import {Help} from '../../components/forms/Help';
+
+const ENDPOINT_ADD_RELATION = '/core/api/zaken_relation';
+const ENDPOINT_ZAKEN = '/core/api/zaken';
+
+const initialState = {
+    errors: '',
+    relationZaakIdentificatie: '',
+    relationZaakUrl: '',
+    aardRelatie: '',
+    isModalOpen: false,
+
+};
+
+
+function reducer(draft, action) {
+    switch (action.type) {
+        case 'UPDATE_ZAAK_RELATION': {
+            draft.relationZaakUrl = action.payload.value;
+            break;
+        }
+        case 'UPDATE_AARD_RELATIE': {
+            draft.aardRelatie = action.payload;
+            break;
+        }
+        case 'VALIDATION_ERRORS': {
+            draft.errors = action.payload;
+            break;
+        }
+        case 'SET_MODAL_STATE': {
+            draft.isModalOpen = action.payload;
+            draft.errors = '';
+            draft.relationZaakIdentificatie = '';
+            draft.aardRelatie = '';
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+
+const getZaken = async (inputValue) => {
+    const response = await get(ENDPOINT_ZAKEN, {identificatie: inputValue});
+    return response.map( (zaak) => {
+        return {
+            value: zaak.url,
+            label: `${zaak.identificatie} (${zaak.bronorganisatie})`,
+        };
+    } );
+};
+
+
+const AddZaakRelation = ({ zaakUrl, csrfToken, onSuccessfulSubmit }) => {
+    const [state, dispatch] = useImmerReducer(reducer, initialState);
+    const closeModal = () => {
+        dispatch({type: 'SET_MODAL_STATE', payload: false});
+    };
+
+    const onSubmit = async (event) => {
+        event.preventDefault();
+
+        const data = new FormData();
+        data.append('csrfmiddlewaretoken', csrfToken);
+        data.append('main_zaak', zaakUrl);
+        data.append('relation_zaak', state.relationZaakUrl);
+        data.append('aard_relatie', state.aardRelatie);
+
+        // post the form
+        const response = await apiCall(
+            ENDPOINT_ADD_RELATION,
+            {
+                method: 'POST',
+                body: data
+            }
+        );
+
+        if (response.ok) {
+            dispatch({type: 'SET_MODAL_STATE', payload: false});
+            onSuccessfulSubmit();
+        } else if (response.status >= 500) {
+            throw new Error('Server error.');
+        } else if (response.status === 400) {
+            const responseData = await response.json();
+            dispatch({
+                type: 'VALIDATION_ERRORS',
+                payload: responseData,
+            });
+        }
+    };
+
+    const relationZaakErrors = state.errors.relationZaak ? state.errors.relationZaak : [];
+
+    return (
+        <React.Fragment>
+            <div className='btn-row'>
+                <a
+                    href='#'
+                    role='button'
+                    className='btn btn--small'
+                    onClick={ (e) => {
+                        e.preventDefault();
+                        dispatch({type: 'SET_MODAL_STATE', payload: true});
+                    } }
+                >
+                <i className='material-icons'>add</i>
+                Relatie toevoegen
+                </a>
+            </div>
+
+            <Modal
+              isOpen={ state.isModalOpen }
+              className='modal'
+              onRequestClose={closeModal}
+            >
+                <button onClick={ closeModal } className='modal__close btn'>&times;</button>
+                <h1 className='page-title'>Relatie toevoegen</h1>
+                <form onSubmit={ onSubmit }>
+                    <HiddenInput id='id_main_zaak' name='main_zaak' value={zaakUrl}/>
+                    <Wrapper errors={relationZaakErrors}>
+                        <Label label='Identificatie' required={true} />
+                        <Help helpText='Voeg de identificatie toe van de zaak die u wilt relateren.' />
+                        <ErrorList errors={relationZaakErrors} />
+                         <AsyncSelect
+                            autoFocus
+                            isClearable
+                            cacheOptions
+                            defaultOptions={false}
+                            loadOptions={ getZaken }
+                            onChange={ (value) => dispatch({
+                                type: 'UPDATE_ZAAK_RELATION',
+                                payload: value ? value : ''
+                            }) }
+                        />
+                    </Wrapper>
+                    <Select
+                        name='aard_relatie'
+                        id='id_aard_relatie'
+                        label='Aard relatie'
+                        required={true}
+                        helpText='Aard van de relatie tussen de zaken.'
+                        choices={[['', '------']].concat(AARD_RELATIES)}
+                        value={state.aardRelatie}
+                        onChange={(event) => dispatch({
+                            type: 'UPDATE_AARD_RELATIE',
+                            payload: event.target.value
+                        })}
+                        errors={state.errors.aardRelatie ? state.errors.aardRelatie : []}
+                    />
+                    <div className='modal__submitrow'>
+                        <SubmitRow text='Toevoegen' />
+                    </div>
+                </form>
+            </Modal>
+
+        </React.Fragment>
+    );
+};
+
+export {AddZaakRelation};

--- a/src/zac/js/views/zaak-detail/AddZaakRelation.js
+++ b/src/zac/js/views/zaak-detail/AddZaakRelation.js
@@ -11,7 +11,7 @@ import {Label} from '../../components/forms/Label';
 import {Help} from '../../components/forms/Help';
 
 const ENDPOINT_ADD_RELATION = '/core/api/zaken_relation';
-const ENDPOINT_ZAKEN = '/core/api/zaken';
+const ENDPOINT_ZAKEN = '/core/api/zaken_search';
 
 const initialState = {
     errors: '',
@@ -124,7 +124,7 @@ const AddZaakRelation = ({ zaakUrl, csrfToken, onSuccessfulSubmit }) => {
               onRequestClose={closeModal}
             >
                 <button onClick={ closeModal } className='modal__close btn'>&times;</button>
-                <h1 className='page-title'>Relatie toevoegen</h1>
+                <div className='page-title'>Relatie toevoegen</div>
                 <form onSubmit={ onSubmit }>
                     <Wrapper errors={state.errors.nonFieldErrors}>
                         <ErrorList errors={state.errors.nonFieldErrors} />

--- a/src/zac/js/views/zaak-detail/AddZaakRelation.js
+++ b/src/zac/js/views/zaak-detail/AddZaakRelation.js
@@ -126,6 +126,9 @@ const AddZaakRelation = ({ zaakUrl, csrfToken, onSuccessfulSubmit }) => {
                 <button onClick={ closeModal } className='modal__close btn'>&times;</button>
                 <h1 className='page-title'>Relatie toevoegen</h1>
                 <form onSubmit={ onSubmit }>
+                    <Wrapper errors={state.errors.nonFieldErrors}>
+                        <ErrorList errors={state.errors.nonFieldErrors} />
+                    </Wrapper>
                     <HiddenInput id='id_main_zaak' name='main_zaak' value={zaakUrl}/>
                     <Wrapper errors={relationZaakErrors}>
                         <Label label='Identificatie' required={true} />

--- a/src/zac/js/views/zaak-detail/index.js
+++ b/src/zac/js/views/zaak-detail/index.js
@@ -10,10 +10,7 @@ import { jsonScriptToVar } from '../../utils/json-script';
 import { AddZaakDocument } from './AddZaakDocument';
 import BetrokkenenTable from '../../components/betrokkenen/Betrokkenen';
 import {AddZaakRelation} from './AddZaakRelation';
-import {apiCall} from "../../utils/fetch";
 
-
-const ENDPOINT_FLUSH_CACHE = '/core/_flush-cache/';
 
 const initReviewRequests = () => {
     const node = document.getElementById('review-requests-react');
@@ -80,26 +77,8 @@ const initZakenRelations = () => {
 
     Modal.setAppElement(node);
 
-    const refreshCache = async () => {
-
-        const data = new FormData();
-        data.append('csrfmiddlewaretoken', csrftoken);
-
-        await apiCall(
-            ENDPOINT_FLUSH_CACHE,
-            {
-                method: 'POST',
-                body: data,
-            }
-        );
-
-        window.location.reload()
-    };
-
     ReactDOM.render(
-        //FIXME
-        // Currently the cache needs to be flushed, otherwise the new zaak relation doesn't appear
-        <AddZaakRelation zaakUrl={zaak} csrfToken={csrftoken} onSuccessfulSubmit={refreshCache} />,
+        <AddZaakRelation zaakUrl={zaak} csrfToken={csrftoken} onSuccessfulSubmit={() => window.location.reload()} />,
         node,
     );
 };

--- a/src/zac/js/views/zaak-detail/index.js
+++ b/src/zac/js/views/zaak-detail/index.js
@@ -9,6 +9,7 @@ import { DownloadUrlContext } from '../../components/documents/context';
 import { jsonScriptToVar } from '../../utils/json-script';
 import { AddZaakDocument } from './AddZaakDocument';
 import BetrokkenenTable from '../../components/betrokkenen/Betrokkenen';
+import {AddZaakRelation} from './AddZaakRelation';
 
 const initReviewRequests = () => {
     const node = document.getElementById('review-requests-react');
@@ -65,10 +66,28 @@ const initBetrokkenenTable = () => {
     );
 };
 
+const initZakenRelations = () => {
+    const node = document.getElementById('add-zaken-relation');
+    if (!node) {
+        return;
+    }
+
+    const { zaak, csrftoken } = node.dataset;
+
+    Modal.setAppElement(node);
+
+    ReactDOM.render(
+        // TODO: Deal with flushing cache?
+        <AddZaakRelation zaakUrl={zaak} csrfToken={csrftoken} onSuccessfulSubmit={() => window.location.reload()} />,
+        node,
+    );
+};
+
 const init = () => {
     initReviewRequests();
     initDocuments();
     initBetrokkenenTable();
+    initZakenRelations();
 };
 
 init();

--- a/src/zac/js/views/zaak-detail/index.js
+++ b/src/zac/js/views/zaak-detail/index.js
@@ -10,6 +10,10 @@ import { jsonScriptToVar } from '../../utils/json-script';
 import { AddZaakDocument } from './AddZaakDocument';
 import BetrokkenenTable from '../../components/betrokkenen/Betrokkenen';
 import {AddZaakRelation} from './AddZaakRelation';
+import {apiCall} from "../../utils/fetch";
+
+
+const ENDPOINT_FLUSH_CACHE = '/core/_flush-cache/';
 
 const initReviewRequests = () => {
     const node = document.getElementById('review-requests-react');
@@ -76,9 +80,26 @@ const initZakenRelations = () => {
 
     Modal.setAppElement(node);
 
+    const refreshCache = async () => {
+
+        const data = new FormData();
+        data.append('csrfmiddlewaretoken', csrftoken);
+
+        await apiCall(
+            ENDPOINT_FLUSH_CACHE,
+            {
+                method: 'POST',
+                body: data,
+            }
+        );
+
+        window.location.reload()
+    };
+
     ReactDOM.render(
-        // TODO: Deal with flushing cache?
-        <AddZaakRelation zaakUrl={zaak} csrfToken={csrftoken} onSuccessfulSubmit={() => window.location.reload()} />,
+        //FIXME
+        // Currently the cache needs to be flushed, otherwise the new zaak relation doesn't appear
+        <AddZaakRelation zaakUrl={zaak} csrfToken={csrftoken} onSuccessfulSubmit={refreshCache} />,
         node,
     );
 };


### PR DESCRIPTION
Related ticket: #109 

An additional form in the zaak detail page was added. In this form, the related zaak and the type of relation can be filled out.