### PR TITLE
Fixing race condition bug on Kownsl approval/advice

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ django-appconf==1.0.3     # via django-axes
 django-auth-adfs-db==0.2.0  # via -r requirements/base.in
 django-auth-adfs==1.3.1   # via django-auth-adfs-db
 django-axes==5.0.13       # via -r requirements/base.in
-django-camunda==0.9.3     # via -r requirements/base.in
+django-camunda==0.9.6     # via -r requirements/base.in
 django-choices==1.7.0     # via -r requirements/base.in, zgw-consumers
 django-compat==1.0.15     # via django-hijack, django-hijack-admin
 django-extra-views==0.13.0  # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -24,7 +24,7 @@ django-appconf==1.0.3     # via -r requirements/base.txt, django-axes
 django-auth-adfs-db==0.2.0  # via -r requirements/base.txt
 django-auth-adfs==1.3.1   # via -r requirements/base.txt, django-auth-adfs-db
 django-axes==5.0.13       # via -r requirements/base.txt
-django-camunda==0.9.3     # via -r requirements/base.txt
+django-camunda==0.9.6     # via -r requirements/base.txt
 django-choices==1.7.0     # via -r requirements/base.txt, zgw-consumers
 django-compat==1.0.15     # via -r requirements/base.txt, django-hijack, django-hijack-admin
 django-extra-views==0.13.0  # via -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,7 +31,7 @@ django-appconf==1.0.3     # via -r requirements/ci.txt, django-axes
 django-auth-adfs-db==0.2.0  # via -r requirements/ci.txt
 django-auth-adfs==1.3.1   # via -r requirements/ci.txt, django-auth-adfs-db
 django-axes==5.0.13       # via -r requirements/ci.txt
-django-camunda==0.9.3     # via -r requirements/ci.txt
+django-camunda==0.9.6     # via -r requirements/ci.txt
 django-choices==1.7.0     # via -r requirements/ci.txt, zgw-consumers
 django-compat==1.0.15     # via -r requirements/ci.txt, django-hijack, django-hijack-admin
 django-debug-toolbar==1.11  # via -r requirements/dev.in

--- a/src/zac/camunda/data.py
+++ b/src/zac/camunda/data.py
@@ -7,6 +7,8 @@ from django_camunda.api import get_process_instance_variable, get_task_variable
 from django_camunda.camunda_models import Model, Task as _Task
 from django_camunda.types import CamundaId
 
+from .history import get_historical_variable
+
 
 @dataclass
 class ProcessInstance(Model):
@@ -23,7 +25,11 @@ class ProcessInstance(Model):
     messages: list = field(default_factory=list)
     tasks: list = field(default_factory=list)
 
+    historical: bool = False
+
     def get_variable(self, name: str) -> Any:
+        if self.historical:
+            return get_historical_variable(self.id, name)
         return get_process_instance_variable(self.id, name)
 
     def title(self) -> str:
@@ -32,6 +38,8 @@ class ProcessInstance(Model):
 
 @dataclass
 class Task(_Task):
+    historical: bool = False
+
     def has_form(self) -> bool:
         return bool(self.form)
 

--- a/src/zac/camunda/history.py
+++ b/src/zac/camunda/history.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from django_camunda.client import get_client
+from django_camunda.types import CamundaId
+from django_camunda.utils import deserialize_variable
+
+
+def get_historical_variable(instance_id: CamundaId, name: str) -> Any:
+    client = get_client()
+
+    response = client.get(
+        "history/variable-instance",
+        {
+            "processInstanceId": instance_id,
+            "variableName": name,
+            "deserializeValues": "false",
+        },
+    )
+    values = sorted(response, key=lambda val: val["create_time"], reverse=True)
+    return deserialize_variable(values[0])

--- a/src/zac/camunda/process_instances.py
+++ b/src/zac/camunda/process_instances.py
@@ -16,19 +16,21 @@ def get_process_instance(instance_id: CamundaId) -> Optional[ProcessInstance]:
     try:
         data = client.get(f"process-instance/{instance_id}")
     except requests.HTTPError as exc:
-        if exc.response.status_code == 404:
-            # check the history
-            try:
-                data = client.get(f"history/process-instance/{instance_id}")
-            except requests.HTTPError as history_exc:
-                if history_exc.response.status_code == 404:
-                    return None
-                raise
-            data = {
-                **data,
+        if exc.response.status_code != 404:
+            raise
+
+        # check the history
+        try:
+            data = client.get(f"history/process-instance/{instance_id}")
+        except requests.HTTPError as history_exc:
+            if history_exc.response.status_code == 404:
+                return None
+            raise
+
+        data.update(
+            {
                 "definition_id": data["process_definition_id"],
                 "historical": True,
             }
-        else:
-            raise
+        )
     return factory(ProcessInstance, data)

--- a/src/zac/camunda/processes.py
+++ b/src/zac/camunda/processes.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 from django_camunda.camunda_models import ProcessDefinition
 from django_camunda.client import Camunda, get_client
 from zgw_consumers.api_models.base import factory
-from zgw_consumers.concurrent import parallel
 
 from zac.core.camunda import get_process_tasks
 

--- a/src/zac/camunda/tests/test_fetch_process_instances.py
+++ b/src/zac/camunda/tests/test_fetch_process_instances.py
@@ -187,4 +187,5 @@ class ProcessInstanceTests(TestCase):
             }
         ]
 
+        self.maxDiff = None
         self.assertEqual(data, expected_data)

--- a/src/zac/core/camunda.py
+++ b/src/zac/core/camunda.py
@@ -56,12 +56,15 @@ def get_process_tasks(process: ProcessInstance) -> List[Task]:
     return tasks
 
 
-def get_task(task_id: CamundaId) -> Optional[Task]:
+def get_task(task_id: CamundaId, check_history=False) -> Optional[Task]:
     client = get_client()
     try:
         data = client.get(f"task/{task_id}")
     except requests.HTTPError as exc:
         if exc.response.status_code == 404:
+            if not check_history:
+                return None
+
             # see if we can get it from the history
             historical = client.get("history/task", {"taskId": task_id})
             if not historical:

--- a/src/zac/core/camunda.py
+++ b/src/zac/core/camunda.py
@@ -3,11 +3,9 @@ from typing import List, Optional
 from django.contrib.auth import get_user_model
 
 import requests
+from django_camunda.camunda_models import factory
 from django_camunda.client import get_client
 from django_camunda.types import CamundaId
-from zgw_consumers.api_models.base import (  # django_camunda can't handle inheritance yet
-    factory,
-)
 
 from zac.camunda.data import ProcessInstance, Task
 from zac.camunda.forms import extract_task_form

--- a/src/zac/core/tests/test_claim_usertask.py
+++ b/src/zac/core/tests/test_claim_usertask.py
@@ -15,7 +15,7 @@ from .mocks import get_camunda_task_mock
 
 
 @requests_mock.Mocker()
-class BPMNMessageSendTests(TestCase):
+class ClaimUserTaskTests(TestCase):
     url = reverse_lazy("core:claim-task")
 
     @classmethod
@@ -100,6 +100,10 @@ class BPMNMessageSendTests(TestCase):
         m.get(
             f"https://camunda.example.com/engine-rest/task/{TASK_ID}",
             status_code=404,
+        )
+        m.get(
+            f"https://camunda.example.com/engine-rest/history/task?taskId={TASK_ID}",
+            json=[],
         )
 
         response = self.client.post(

--- a/src/zac/core/tests/test_send_bpmn_message.py
+++ b/src/zac/core/tests/test_send_bpmn_message.py
@@ -7,11 +7,12 @@ from django.urls import reverse_lazy
 import requests_mock
 
 from zac.accounts.tests.factories import SuperUserFactory, UserFactory
+from zac.core.tests.utils import ClearCachesMixin
 from zgw.models import Zaak
 
 
 @requests_mock.Mocker()
-class BPMNMessageSendTests(TestCase):
+class BPMNMessageSendTests(ClearCachesMixin, TestCase):
     url = reverse_lazy("core:send-message")
 
     @classmethod
@@ -70,7 +71,6 @@ class BPMNMessageSendTests(TestCase):
             relevante_andere_zaken=[],
             zaakgeometrie={},
         )
-
         response = self.client.post(
             self.url,
             {
@@ -178,6 +178,30 @@ class BPMNMessageSendTests(TestCase):
         m.get(
             f"https://camunda.example.com/engine-rest/process-instance/{PROCESS_INSTANCE_ID}",
             status_code=404,
+        )
+        m.get(
+            f"https://camunda.example.com/engine-rest/history/process-instance/{PROCESS_INSTANCE_ID}",
+            json={
+                "id": PROCESS_INSTANCE_ID,
+                "businessKey": None,
+                "processDefinitionId": "invoice:1:7bf79f13-ef95-11e6-b6e6-34f39ab71d4e",
+                "processDefinitionKey": "invoice",
+                "processDefinitionName": "Invoice Receipt",
+                "processDefinitionVersion": 1,
+                "startTime": "2017-02-10T14:33:19.000+0200",
+                "endTime": None,
+                "removalTime": None,
+                "durationInMillis": None,
+                "startUserId": None,
+                "startActivityId": "StartEvent_1",
+                "deleteReason": None,
+                "rootProcessInstanceId": "f8259e5d-ab9d-11e8-8449-e4a7a094a9d6",
+                "superProcessInstanceId": None,
+                "superCaseInstanceId": None,
+                "caseInstanceId": None,
+                "tenantId": None,
+                "state": "ACTIVE",
+            },
         )
 
         response = self.client.post(

--- a/src/zac/core/tests/test_submit_usertask.py
+++ b/src/zac/core/tests/test_submit_usertask.py
@@ -1,18 +1,18 @@
 import base64
 import json
 import uuid
-from datetime import date
 from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 import requests_mock
 from django_camunda.utils import serialize_variable
 from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.catalogi import ZaakType
 
-from zac.accounts.tests.factories import SuperUserFactory, UserFactory
+from zac.accounts.tests.factories import SuperUserFactory
 from zac.core.tests.utils import ClearCachesMixin
 from zac.tests.utils import generate_oas_component
 from zgw.models import Zaak
@@ -36,6 +36,30 @@ TASK = {
     "suspended": False,
     "formKey": "zac:doRedirect",
     "tenantId": "aTenantId",
+}
+
+HISTORIC_TASK = {
+    "processDefinitionId": "aProcDefId",
+    "executionId": "anExecution",
+    "caseDefinitionId": "aCaseDefId",
+    "caseInstanceId": "aCaseInstId",
+    "caseExecutionId": "aCaseExecution",
+    "activityInstanceId": "anActInstId",
+    "name": "aName",
+    "description": "aDescription",
+    "deleteReason": "aDeleteReason",
+    "owner": "anOwner",
+    "startTime": "2013-01-23T13:42:42.000+0200",
+    "endTime": "2013-01-23T13:45:42.000+0200",
+    "duration": 2000,
+    "taskDefinitionKey": "aTaskDefinitionKey",
+    "priority": 42,
+    "due": "2013-01-23T13:49:42.000+0200",
+    "parentTaskId": None,
+    "followUp": "2013-01-23T13:44:42.000+0200",
+    "tenantId": None,
+    "removalTime": "2018-02-10T14:33:19.000+0200",
+    "rootProcessInstanceId": "aRootProcessInstanceId",
 }
 
 
@@ -126,3 +150,86 @@ class SubmitRedirectUserTaskTests(ClearCachesMixin, TestCase):
             self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
         mock_complete_task.assert_called_once_with(uuid.UUID(task_id), {})
+
+    def test_task_already_completed(self, m):
+        # set up the Camunda mocks for a "completed" task (because of webhook, for example)
+        PROCESS_INSTANCE_ID = "f0a2e2c4-b35c-49f1-9fba-aaa7a161f247"
+        ZAAK_URL = "https://open-zaak.nl/zaken/api/v1/zaken/1234"
+        task_id = str(uuid.uuid4())
+        url = reverse("core:redirect-task", kwargs={"task_id": task_id})
+        state = json.dumps(
+            {
+                "user_id": self.user.id,
+                "task_id": task_id,
+            }
+        ).encode("utf-8")
+        m.get(
+            f"https://camunda.example.com/engine-rest/task/{task_id}", status_code=404
+        )
+        m.get(
+            f"https://camunda.example.com/engine-rest/process-instance/{PROCESS_INSTANCE_ID}",
+            status_code=404,
+        )
+        m.get(
+            f"https://camunda.example.com/engine-rest/history/task?taskId={task_id}",
+            json=[
+                {
+                    **HISTORIC_TASK,
+                    "id": task_id,
+                    "assignee": self.user.username,
+                    "processInstanceId": PROCESS_INSTANCE_ID,
+                }
+            ],
+        )
+        m.get(
+            f"https://camunda.example.com/engine-rest/history/process-instance/{PROCESS_INSTANCE_ID}",
+            json={
+                "id": PROCESS_INSTANCE_ID,
+                "processDefinitionId": "proces:1",
+                "businessKey": "",
+                "caseInstanceId": "",
+                "state": "COMPLETED",
+                "tenantId": "",
+            },
+        )
+        m.get(
+            (
+                "https://camunda.example.com/engine-rest/history/variable-instance"
+                f"?variableName=zaakUrl&deserializeValues=false&processInstanceId={PROCESS_INSTANCE_ID}"
+            ),
+            json=[
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "zaakUrl",
+                    "processInstanceId": PROCESS_INSTANCE_ID,
+                    "createTime": timezone.now().isoformat(),
+                    **serialize_variable(ZAAK_URL),
+                }
+            ],
+        )
+        zaaktype = factory(ZaakType, generate_oas_component("ztc", "schemas/ZaakType"))
+        zaak = factory(
+            Zaak,
+            generate_oas_component(
+                "zrc",
+                "schemas/Zaak",
+                url=ZAAK_URL,
+                zaaktype=zaaktype.url,
+            ),
+        )
+
+        with patch("zac.core.views.processes.get_zaak", return_value=zaak), patch(
+            "zac.core.views.processes.fetch_zaaktype", return_value=zaaktype
+        ), patch("zac.core.views.processes.complete_task") as mock_complete_task:
+            response = self.client.get(url, {"state": base64.b64encode(state)})
+
+            expected_url = reverse(
+                "core:zaak-detail",
+                kwargs={
+                    "bronorganisatie": zaak.bronorganisatie,
+                    "identificatie": zaak.identificatie,
+                },
+            )
+            self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+        mock_complete_task.assert_not_called()

--- a/src/zac/core/tests/test_submit_usertask.py
+++ b/src/zac/core/tests/test_submit_usertask.py
@@ -1,0 +1,128 @@
+import base64
+import json
+import uuid
+from datetime import date
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+
+import requests_mock
+from django_camunda.utils import serialize_variable
+from zgw_consumers.api_models.base import factory
+from zgw_consumers.api_models.catalogi import ZaakType
+
+from zac.accounts.tests.factories import SuperUserFactory, UserFactory
+from zac.core.tests.utils import ClearCachesMixin
+from zac.tests.utils import generate_oas_component
+from zgw.models import Zaak
+
+TASK = {
+    "name": "aName",
+    "created": "2013-01-23T13:42:42.000+0200",
+    "due": "2013-01-23T13:49:42.576+0200",
+    "followUp": "2013-01-23T13:44:42.437+0200",
+    "delegationState": "RESOLVED",
+    "description": "",
+    "executionId": "",
+    "owner": "anOwner",
+    "parentTaskId": None,
+    "priority": 50,
+    "processDefinitionId": "aProcDefId",
+    "caseDefinitionId": "aCaseDefId",
+    "caseInstanceId": "aCaseInstId",
+    "caseExecutionId": "aCaseExecution",
+    "taskDefinitionKey": "aTaskDefinitionKey",
+    "suspended": False,
+    "formKey": "zac:doRedirect",
+    "tenantId": "aTenantId",
+}
+
+
+@requests_mock.Mocker()
+class SubmitRedirectUserTaskTests(ClearCachesMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(user=self.user)
+
+        extract_form_patcher = patch(
+            "zac.core.camunda.extract_task_form", return_value=None
+        )
+        extract_form_patcher.start()
+        self.addCleanup(extract_form_patcher.stop)
+
+    def test_task_not_yet_completed(self, m):
+        """
+        Test that the redirect task view completes the task when needed.
+        """
+        # set up the Camunda mocks for a "live" task
+        PROCESS_INSTANCE_ID = "f0a2e2c4-b35c-49f1-9fba-aaa7a161f247"
+        ZAAK_URL = "https://open-zaak.nl/zaken/api/v1/zaken/1234"
+        task_id = str(uuid.uuid4())
+        url = reverse("core:redirect-task", kwargs={"task_id": task_id})
+        state = json.dumps(
+            {
+                "user_id": self.user.id,
+                "task_id": task_id,
+            }
+        ).encode("utf-8")
+        m.get(
+            f"https://camunda.example.com/engine-rest/task/{task_id}",
+            json={
+                **TASK,
+                "id": task_id,
+                "assignee": self.user.username,
+                "processInstanceId": PROCESS_INSTANCE_ID,
+            },
+        )
+        m.get(
+            f"https://camunda.example.com/engine-rest/process-instance/{PROCESS_INSTANCE_ID}",
+            json={
+                "id": PROCESS_INSTANCE_ID,
+                "definitionId": "proces:1",
+                "businessKey": "",
+                "caseInstanceId": "",
+                "suspended": False,
+                "tenantId": "",
+            },
+        )
+        m.get(
+            (
+                "https://camunda.example.com/engine-rest/process-instance/"
+                f"{PROCESS_INSTANCE_ID}/variables/zaakUrl?deserializeValues=false"
+            ),
+            json=serialize_variable(ZAAK_URL),
+        )
+
+        zaaktype = factory(ZaakType, generate_oas_component("ztc", "schemas/ZaakType"))
+        zaak = factory(
+            Zaak,
+            generate_oas_component(
+                "zrc",
+                "schemas/Zaak",
+                url=ZAAK_URL,
+                zaaktype=zaaktype.url,
+            ),
+        )
+
+        with patch("zac.core.views.processes.get_zaak", return_value=zaak), patch(
+            "zac.core.views.processes.fetch_zaaktype", return_value=zaaktype
+        ), patch("zac.core.views.processes.complete_task") as mock_complete_task:
+            response = self.client.get(url, {"state": base64.b64encode(state)})
+
+            expected_url = reverse(
+                "core:zaak-detail",
+                kwargs={
+                    "bronorganisatie": zaak.bronorganisatie,
+                    "identificatie": zaak.identificatie,
+                },
+            )
+            self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+        mock_complete_task.assert_called_once_with(uuid.UUID(task_id), {})

--- a/src/zac/core/views/processes.py
+++ b/src/zac/core/views/processes.py
@@ -134,8 +134,8 @@ class UserTaskMixin:
         self.check_object_permissions(zaak)
         return zaak
 
-    def _get_task(self):
-        if not hasattr(self, "_task"):
+    def _get_task(self, refresh=False):
+        if not hasattr(self, "_task") or refresh:
             task = get_task(self.kwargs["task_id"])
             if task is None:
                 raise Http404("No such task")
@@ -364,8 +364,9 @@ class RedirectTaskView(PermissionRequiredMixin, UserTaskMixin, RedirectView):
         return state
 
     def complete_task(self) -> HttpResponseRedirect:
-        task = self._get_task()
-        complete_task(task.id, {})
+        task = self._get_task(refresh=True)
+        if not task.historical:
+            complete_task(task.id, {})
         zaak_detail = reverse(
             "core:zaak-detail",
             kwargs={

--- a/src/zac/core/views/processes.py
+++ b/src/zac/core/views/processes.py
@@ -124,6 +124,8 @@ class FormSetMixin:
 
 
 class UserTaskMixin:
+    check_task_history = False
+
     def get_zaak(self):
         task = self._get_task()
         process_instance = get_process_instance(task.process_instance_id)
@@ -136,7 +138,9 @@ class UserTaskMixin:
 
     def _get_task(self, refresh=False):
         if not hasattr(self, "_task") or refresh:
-            task = get_task(self.kwargs["task_id"])
+            task = get_task(
+                self.kwargs["task_id"], check_history=self.check_task_history
+            )
             if task is None:
                 raise Http404("No such task")
             self._task = task
@@ -268,6 +272,7 @@ class PerformTaskView(PermissionRequiredMixin, FormSetMixin, UserTaskMixin, Form
 
 class RedirectTaskView(PermissionRequiredMixin, UserTaskMixin, RedirectView):
     permission_required = zaakproces_usertasks.name
+    check_task_history = True
 
     def get(self, request, *args, **kwargs):
         # check if we're returning from an external application - indicated by the

--- a/src/zac/core/views/processes.py
+++ b/src/zac/core/views/processes.py
@@ -49,7 +49,7 @@ class SendMessage(PermissionRequiredMixin, FormView):
 
         # set the valid process instance messages _if_ a process instance exists
         process_instance = get_process_instance(process_instance_id)
-        if process_instance is None:
+        if process_instance is None or process_instance.historical:
             return form
 
         messages = get_messages(process_instance.definition_id)


### PR DESCRIPTION
When Kownsl advices/approvals are recorded, notifications are sent and
handled by the ZAC. These handlers comlete the user task in the
Camunda process. Sometimes, these notifications can arrive before the
redirect is triggered, which also completes the user task.

The code is now adapted for this race condition where the notification
is handled before the redirect. In that case, the return URL validates
against the historic process instance/task, and if it's a historic
entry, it no longer attempts to complete the user task (since that
has been done already)

- [x] Reproduce
- [x] Handle race condition
- [x] Tests for history API fallback