### PR TITLE
Invalidate cache on mutation of zaaktype/informatieobjecttype

### DIFF
--- a/backend/src/zac/core/cache.py
+++ b/backend/src/zac/core/cache.py
@@ -13,6 +13,11 @@ from zgw.models.zrc import Zaak
 ALL_VAS_SORTED = list(VertrouwelijkheidsAanduidingen.values.keys())
 
 
+def invalidate_zaaktypen_cache(catalogus: str = ""):
+    key = f"zaaktypen:{catalogus}"
+    cache.delete(key)
+
+
 def invalidate_zaak_cache(zaak: Zaak):
     zaak_uuids = (None, zaak.uuid)
     zaak_urls = (None, zaak.url)

--- a/backend/src/zac/core/cache.py
+++ b/backend/src/zac/core/cache.py
@@ -18,6 +18,11 @@ def invalidate_zaaktypen_cache(catalogus: str = ""):
     cache.delete(key)
 
 
+def invalidate_informatieobjecttypen_cache(catalogus: str = ""):
+    key = f"informatieobjecttypen:{catalogus}"
+    cache.delete(key)
+
+
 def invalidate_zaak_cache(zaak: Zaak):
     zaak_uuids = (None, zaak.uuid)
     zaak_urls = (None, zaak.url)

--- a/backend/src/zac/core/services.py
+++ b/backend/src/zac/core/services.py
@@ -115,7 +115,7 @@ def _get_zaaktypen(catalogus: str = "") -> List[ZaakType]:
     return factory(ZaakType, results)
 
 
-@cache_result("informatieobjecttype:{catalogus}", timeout=AN_HOUR)
+@cache_result("informatieobjecttypen:{catalogus}", timeout=AN_HOUR)
 def get_informatieobjecttypen(catalogus: str = "") -> List[InformatieObjectType]:
     """
     Retrieve all the specified informatieobjecttypen from all catalogi in the configured APIs.

--- a/backend/src/zac/notifications/handlers.py
+++ b/backend/src/zac/notifications/handlers.py
@@ -1,0 +1,82 @@
+from zgw_consumers.api_models.base import factory
+from zgw_consumers.api_models.zaken import Zaak
+
+from zac.activities.models import Activity
+from zac.core.cache import invalidate_zaak_cache, invalidate_zaak_list_cache
+from zac.core.services import _client_from_url
+from zac.elasticsearch.api import (
+    create_zaak_document,
+    delete_zaak_document,
+    update_rollen_in_zaak_document,
+    update_zaak_document,
+)
+
+
+class ZakenHandler:
+    def handle(self, data: dict) -> None:
+        if data["resource"] == "zaak":
+            if data["actie"] == "create":
+                self._handle_zaak_creation(data["hoofd_object"])
+            elif data["actie"] in ["update", "partial_update"]:
+                self._handle_zaak_update(data["hoofd_object"])
+            elif data["actie"] == "destroy":
+                self._handle_zaak_destroy(data["hoofd_object"])
+        elif (
+            data["resource"] in ["resultaat", "status", "zaakeigenschap"]
+            and data["actie"] == "create"
+        ):
+            self._handle_related_creation(data["hoofd_object"])
+
+        elif data["resource"] == "rol":
+            self._handle_rol_change(data["hoofd_object"])
+
+    @staticmethod
+    def _retrieve_zaak(zaak_url) -> Zaak:
+        client = _client_from_url(zaak_url)
+        zaak = client.retrieve("zaak", url=zaak_url)
+        return factory(Zaak, zaak)
+
+    def _handle_zaak_update(self, zaak_url: str):
+        zaak = self._retrieve_zaak(zaak_url)
+        invalidate_zaak_cache(zaak)
+        # index in ES
+        update_zaak_document(zaak)
+
+    def _handle_zaak_creation(self, zaak_url: str):
+        client = _client_from_url(zaak_url)
+        zaak = self._retrieve_zaak(zaak_url)
+        invalidate_zaak_list_cache(client, zaak)
+        # index in ES
+        create_zaak_document(zaak)
+
+    def _handle_zaak_destroy(self, zaak_url: str):
+        Activity.objects.filter(zaak=zaak_url).delete()
+        # index in ES
+        delete_zaak_document(zaak_url)
+
+    def _handle_related_creation(self, zaak_url):
+        zaak = self._retrieve_zaak(zaak_url)
+        invalidate_zaak_cache(zaak)
+
+    def _handle_rol_change(self, zaak_url):
+        zaak = self._retrieve_zaak(zaak_url)
+        # index in ES
+        update_rollen_in_zaak_document(zaak)
+
+
+class RoutingHandler:
+    def __init__(self, config: dict, default=None):
+        self.config = config
+        self.default = default
+
+    def handle(self, message: dict):
+        handler = self.config.get(message["kanaal"])
+        if handler is not None:
+            handler.handle(message)
+        elif self.default:
+            self.default.handle(message)
+
+
+handler = RoutingHandler(
+    {"zaken": ZakenHandler()},
+)

--- a/backend/src/zac/notifications/handlers.py
+++ b/backend/src/zac/notifications/handlers.py
@@ -3,6 +3,7 @@ from zgw_consumers.api_models.zaken import Zaak
 
 from zac.activities.models import Activity
 from zac.core.cache import (
+    invalidate_informatieobjecttypen_cache,
     invalidate_zaak_cache,
     invalidate_zaak_list_cache,
     invalidate_zaaktypen_cache,
@@ -71,8 +72,17 @@ class ZakenHandler:
 class ZaaktypenHandler:
     def handle(self, data: dict) -> None:
         if data["resource"] == "zaaktype":
-            if data["actie"] == "create":
+            if data["actie"] in ["create", "update", "partial_update"]:
                 invalidate_zaaktypen_cache(catalogus=data["kenmerken"]["catalogus"])
+
+
+class InformatieObjecttypenHandler:
+    def handle(self, data: dict) -> None:
+        if data["resource"] == "informatieobjecttype":
+            if data["actie"] in ["create", "update", "partial_update"]:
+                invalidate_informatieobjecttypen_cache(
+                    catalogus=data["kenmerken"]["catalogus"]
+                )
 
 
 class RoutingHandler:
@@ -91,6 +101,7 @@ class RoutingHandler:
 handler = RoutingHandler(
     {
         "zaaktypen": ZaaktypenHandler(),
+        "informatieobjecttypen": InformatieObjecttypenHandler(),
         "zaken": ZakenHandler(),
     }
 )

--- a/backend/src/zac/notifications/handlers.py
+++ b/backend/src/zac/notifications/handlers.py
@@ -90,7 +90,7 @@ class RoutingHandler:
         self.config = config
         self.default = default
 
-    def handle(self, message: dict):
+    def handle(self, message: dict) -> None:
         handler = self.config.get(message["kanaal"])
         if handler is not None:
             handler.handle(message)

--- a/backend/src/zac/notifications/handlers.py
+++ b/backend/src/zac/notifications/handlers.py
@@ -64,6 +64,13 @@ class ZakenHandler:
         update_rollen_in_zaak_document(zaak)
 
 
+class ZaaktypenHandler:
+    def handle(self, data: dict) -> None:
+        import bpdb
+
+        bpdb.set_trace()
+
+
 class RoutingHandler:
     def __init__(self, config: dict, default=None):
         self.config = config

--- a/backend/src/zac/notifications/handlers.py
+++ b/backend/src/zac/notifications/handlers.py
@@ -2,7 +2,11 @@ from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.zaken import Zaak
 
 from zac.activities.models import Activity
-from zac.core.cache import invalidate_zaak_cache, invalidate_zaak_list_cache
+from zac.core.cache import (
+    invalidate_zaak_cache,
+    invalidate_zaak_list_cache,
+    invalidate_zaaktypen_cache,
+)
 from zac.core.services import _client_from_url
 from zac.elasticsearch.api import (
     create_zaak_document,
@@ -66,9 +70,9 @@ class ZakenHandler:
 
 class ZaaktypenHandler:
     def handle(self, data: dict) -> None:
-        import bpdb
-
-        bpdb.set_trace()
+        if data["resource"] == "zaaktype":
+            if data["actie"] == "create":
+                invalidate_zaaktypen_cache(catalogus=data["kenmerken"]["catalogus"])
 
 
 class RoutingHandler:
@@ -85,5 +89,8 @@ class RoutingHandler:
 
 
 handler = RoutingHandler(
-    {"zaken": ZakenHandler()},
+    {
+        "zaaktypen": ZaaktypenHandler(),
+        "zaken": ZakenHandler(),
+    }
 )

--- a/backend/src/zac/notifications/subscriptions.py
+++ b/backend/src/zac/notifications/subscriptions.py
@@ -23,6 +23,16 @@ DESIRED = [
         "filters": {},
     },
     {
+        "path": reverse_lazy("notifications:callback"),
+        "channel": "zaaktypen",
+        "filters": {},
+    },
+    {
+        "path": reverse_lazy("notifications:callback"),
+        "channel": "informatieobjecttypen",
+        "filters": {},
+    },
+    {
         "path": reverse_lazy("notifications:kownsl-callback"),
         "channel": "kownsl",
         "filters": {},

--- a/backend/src/zac/notifications/tests/test_documenttype_created.py
+++ b/backend/src/zac/notifications/tests/test_documenttype_created.py
@@ -1,0 +1,66 @@
+from django.urls import reverse
+from django.utils import timezone
+
+import requests_mock
+from rest_framework import status
+from rest_framework.test import APITestCase
+from zgw_consumers.models import APITypes, Service
+from zgw_consumers.test import mock_service_oas_get
+
+from zac.accounts.models import User
+from zac.core.services import get_informatieobjecttypen
+from zac.core.tests.utils import ClearCachesMixin
+from zac.tests.utils import paginated_response
+
+CATALOGUS = "https://some.ztc.nl/api/v1/catalogi/661ff970-6af0-46cf-a228-2c35639ad77e"
+
+NOTIFICATION = {
+    "kanaal": "informatieobjecttypen",
+    "hoofdObject": "https://some.ztc.nl/api/v1/informatieobjecttypen/f3ff2713-2f53-42ff-a154-16842309ad60",
+    "resource": "informatieobjecttype",
+    "resourceUrl": "https://some.ztc.nl/api/v1/informatieobjecttypen/f3ff2713-2f53-42ff-a154-16842309ad60",
+    "actie": "create",
+    "aanmaakdatum": timezone.now().isoformat(),
+    "kenmerken": {"catalogus": CATALOGUS},
+}
+
+
+@requests_mock.Mocker()
+class informatieobjecttypeCreatedTests(ClearCachesMixin, APITestCase):
+    """
+    Test that the appropriate actions happen on zaak-creation notifications.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(username="notifs")
+        cls.ztc = Service.objects.create(
+            api_root="https://some.ztc.nl/api/v1/", api_type=APITypes.ztc
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        self.client.force_authenticate(user=self.user)
+
+    def test_informatieobjecttype_created_invalidate_list_cache(self, m):
+        mock_service_oas_get(m, "https://some.ztc.nl/api/v1/", "ztc")
+        m.get(
+            f"https://some.ztc.nl/api/v1/informatieobjecttypen?catalogus={CATALOGUS}",
+            json=paginated_response([]),
+        )
+
+        # call to populate cache
+        informatieobjecttypen1 = get_informatieobjecttypen(catalogus=CATALOGUS)
+
+        # post the notification
+        response = self.client.post(reverse("notifications:callback"), NOTIFICATION)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # second call should not hit the cache
+        informatieobjecttypen2 = get_informatieobjecttypen(catalogus=CATALOGUS)
+        self.assertEqual(m.call_count, 3)  # 1 call for API spec
+        self.assertEqual(
+            m.request_history[1].url,
+            m.request_history[2].url,
+        )

--- a/backend/src/zac/notifications/tests/test_documenttype_created.py
+++ b/backend/src/zac/notifications/tests/test_documenttype_created.py
@@ -51,14 +51,14 @@ class informatieobjecttypeCreatedTests(ClearCachesMixin, APITestCase):
         )
 
         # call to populate cache
-        informatieobjecttypen1 = get_informatieobjecttypen(catalogus=CATALOGUS)
+        get_informatieobjecttypen(catalogus=CATALOGUS)
 
         # post the notification
         response = self.client.post(reverse("notifications:callback"), NOTIFICATION)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # second call should not hit the cache
-        informatieobjecttypen2 = get_informatieobjecttypen(catalogus=CATALOGUS)
+        get_informatieobjecttypen(catalogus=CATALOGUS)
         self.assertEqual(m.call_count, 3)  # 1 call for API spec
         self.assertEqual(
             m.request_history[1].url,

--- a/backend/src/zac/notifications/tests/test_subscribe_management_command.py
+++ b/backend/src/zac/notifications/tests/test_subscribe_management_command.py
@@ -32,8 +32,8 @@ class SubscribeCommandTests(ClearCachesMixin, TestCase):
 
         result = subscribe_all("https://zac.example.com")
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(len(m.request_history), 3)
+        self.assertEqual(len(result), 4)
+        self.assertEqual(len(m.request_history), 5)
 
         token = Token.objects.get()
         self.assertEqual(
@@ -49,7 +49,7 @@ class SubscribeCommandTests(ClearCachesMixin, TestCase):
                 ],
             },
         )
-        self.assertEqual(Subscription.objects.count(), 2)
+        self.assertEqual(Subscription.objects.count(), 4)
 
     @requests_mock.Mocker()
     def test_verify_existing(self, m):
@@ -79,8 +79,8 @@ class SubscribeCommandTests(ClearCachesMixin, TestCase):
 
         result = subscribe_all("https://zac.example.com")
 
-        self.assertEqual(len(result), 1)
-        self.assertEqual(len(m.request_history), 3)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(len(m.request_history), 5)
 
         token = Token.objects.get()
         self.assertEqual(
@@ -90,10 +90,10 @@ class SubscribeCommandTests(ClearCachesMixin, TestCase):
                 "auth": f"Token {token.key}",
                 "kanalen": [
                     {
-                        "naam": "zaken",
+                        "naam": "informatieobjecttypen",
                         "filters": {},
                     }
                 ],
             },
         )
-        self.assertEqual(Subscription.objects.count(), 2)
+        self.assertEqual(Subscription.objects.count(), 4)

--- a/backend/src/zac/notifications/tests/test_zaaktype_created.py
+++ b/backend/src/zac/notifications/tests/test_zaaktype_created.py
@@ -51,14 +51,14 @@ class ZaakTypeCreatedTests(ClearCachesMixin, APITestCase):
         )
 
         # call to populate cache
-        zaaktypen1 = get_zaaktypen(catalogus=CATALOGUS)
+        get_zaaktypen(catalogus=CATALOGUS)
 
         # post the notification
         response = self.client.post(reverse("notifications:callback"), NOTIFICATION)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # second call should not hit the cache
-        zaaktypen2 = get_zaaktypen(catalogus=CATALOGUS)
+        get_zaaktypen(catalogus=CATALOGUS)
         self.assertEqual(m.call_count, 3)  # 1 call for API spec
         self.assertEqual(
             m.request_history[1].url,

--- a/backend/src/zac/notifications/tests/test_zaaktype_created.py
+++ b/backend/src/zac/notifications/tests/test_zaaktype_created.py
@@ -1,0 +1,66 @@
+from django.urls import reverse
+from django.utils import timezone
+
+import requests_mock
+from rest_framework import status
+from rest_framework.test import APITestCase
+from zgw_consumers.models import APITypes, Service
+from zgw_consumers.test import mock_service_oas_get
+
+from zac.accounts.models import User
+from zac.core.services import get_zaaktypen
+from zac.core.tests.utils import ClearCachesMixin
+from zac.tests.utils import paginated_response
+
+CATALOGUS = "https://some.ztc.nl/api/v1/catalogi/661ff970-6af0-46cf-a228-2c35639ad77e"
+
+NOTIFICATION = {
+    "kanaal": "zaaktypen",
+    "hoofdObject": "https://some.ztc.nl/api/v1/zaaktypen/f3ff2713-2f53-42ff-a154-16842309ad60",
+    "resource": "zaaktype",
+    "resourceUrl": "https://some.ztc.nl/api/v1/zaaktypen/f3ff2713-2f53-42ff-a154-16842309ad60",
+    "actie": "create",
+    "aanmaakdatum": timezone.now().isoformat(),
+    "kenmerken": {"catalogus": CATALOGUS},
+}
+
+
+@requests_mock.Mocker()
+class ZaakTypeCreatedTests(ClearCachesMixin, APITestCase):
+    """
+    Test that the appropriate actions happen on zaak-creation notifications.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(username="notifs")
+        cls.ztc = Service.objects.create(
+            api_root="https://some.ztc.nl/api/v1/", api_type=APITypes.ztc
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        self.client.force_authenticate(user=self.user)
+
+    def test_zaaktype_created_invalidate_list_cache(self, m):
+        mock_service_oas_get(m, "https://some.ztc.nl/api/v1/", "ztc")
+        m.get(
+            f"https://some.ztc.nl/api/v1/zaaktypen?catalogus={CATALOGUS}",
+            json=paginated_response([]),
+        )
+
+        # call to populate cache
+        zaaktypen1 = get_zaaktypen(catalogus=CATALOGUS)
+
+        # post the notification
+        response = self.client.post(reverse("notifications:callback"), NOTIFICATION)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # second call should not hit the cache
+        zaaktypen2 = get_zaaktypen(catalogus=CATALOGUS)
+        self.assertEqual(m.call_count, 3)  # 1 call for API spec
+        self.assertEqual(
+            m.request_history[1].url,
+            m.request_history[2].url,
+        )

--- a/backend/src/zac/notifications/views.py
+++ b/backend/src/zac/notifications/views.py
@@ -1,19 +1,8 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from zgw_consumers.api_models.base import factory
-from zgw_consumers.api_models.zaken import Zaak
 
-from zac.activities.models import Activity
-from zac.core.cache import invalidate_zaak_cache, invalidate_zaak_list_cache
-from zac.core.services import _client_from_url
-from zac.elasticsearch.api import (
-    create_zaak_document,
-    delete_zaak_document,
-    update_rollen_in_zaak_document,
-    update_zaak_document,
-)
-
+from .handlers import handler
 from .serializers import NotificatieSerializer
 
 
@@ -29,55 +18,5 @@ class BaseNotificationCallbackView(APIView):
 
 
 class NotificationCallbackView(BaseNotificationCallbackView):
-    def handle_notification(self, data: dict):
-        if not data["kanaal"] == "zaken":
-            return
-
-        if data["resource"] == "zaak":
-            if data["actie"] == "create":
-                self._handle_zaak_creation(data["hoofd_object"])
-            elif data["actie"] in ["update", "partial_update"]:
-                self._handle_zaak_update(data["hoofd_object"])
-            elif data["actie"] == "destroy":
-                self._handle_zaak_destroy(data["hoofd_object"])
-        elif (
-            data["resource"] in ["resultaat", "status", "zaakeigenschap"]
-            and data["actie"] == "create"
-        ):
-            self._handle_related_creation(data["hoofd_object"])
-
-        elif data["resource"] == "rol":
-            self._handle_rol_change(data["hoofd_object"])
-
-    @staticmethod
-    def _retrieve_zaak(zaak_url) -> Zaak:
-        client = _client_from_url(zaak_url)
-        zaak = client.retrieve("zaak", url=zaak_url)
-        return factory(Zaak, zaak)
-
-    def _handle_zaak_update(self, zaak_url: str):
-        zaak = self._retrieve_zaak(zaak_url)
-        invalidate_zaak_cache(zaak)
-        # index in ES
-        update_zaak_document(zaak)
-
-    def _handle_zaak_creation(self, zaak_url: str):
-        client = _client_from_url(zaak_url)
-        zaak = self._retrieve_zaak(zaak_url)
-        invalidate_zaak_list_cache(client, zaak)
-        # index in ES
-        create_zaak_document(zaak)
-
-    def _handle_zaak_destroy(self, zaak_url: str):
-        Activity.objects.filter(zaak=zaak_url).delete()
-        # index in ES
-        delete_zaak_document(zaak_url)
-
-    def _handle_related_creation(self, zaak_url):
-        zaak = self._retrieve_zaak(zaak_url)
-        invalidate_zaak_cache(zaak)
-
-    def _handle_rol_change(self, zaak_url):
-        zaak = self._retrieve_zaak(zaak_url)
-        # index in ES
-        update_rollen_in_zaak_document(zaak)
+    def handle_notification(self, data: dict) -> None:
+        handler.handle(data)


### PR DESCRIPTION
Fixes a `KeyError` when retrieving a zaak of a newly created zaaktype, while the cache of zaaktypen is still warm and doesn't include the new zaaktype yet.