### PR TITLE
Document internal Camunda process instances endpoint

### DIFF
--- a/backend/src/zac/api/urls.py
+++ b/backend/src/zac/api/urls.py
@@ -17,5 +17,6 @@ urlpatterns = [
     # actual API endpoints
     path("kownsl/", include("zac.contrib.kownsl.urls")),
     path("core/", include("zac.core.api.bff_urls")),
+    path("camunda/", include("zac.camunda.api")),
     path("", include("zac.notifications.urls")),
 ]

--- a/backend/src/zac/camunda/api/serializers.py
+++ b/backend/src/zac/camunda/api/serializers.py
@@ -3,6 +3,10 @@ from rest_framework import serializers
 from zac.accounts.serializers import UserSerializer
 
 
+class ErrorSerializer(serializers.Serializer):
+    error = serializers.CharField()
+
+
 class RecursiveField(serializers.Serializer):
     def to_representation(self, instance):
         return self.parent.parent.to_representation(instance)

--- a/backend/src/zac/camunda/api/views.py
+++ b/backend/src/zac/camunda/api/views.py
@@ -1,23 +1,38 @@
+from drf_spectacular.openapi import OpenApiParameter, OpenApiTypes
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..processes import get_process_instances
-from .serializers import ProcessInstanceSerializer
+from .serializers import ErrorSerializer, ProcessInstanceSerializer
 
 
 class ProcessInstanceFetchView(APIView):
-    schema = None
+    serializer_class = ProcessInstanceSerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "zaak_url",
+                OpenApiTypes.URI,
+                OpenApiParameter.QUERY,
+                required=True,
+            )
+        ],
+        responses={
+            200: serializer_class(many=True),
+            400: ErrorSerializer,
+        },
+    )
     def get(self, request: Request, *args, **kwargs):
         zaak_url = request.GET.get("zaak_url")
         if not zaak_url:
-            return Response(
-                {"error": "missing zaak_url"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            err_serializer = ErrorSerializer(data={"error": "missing zaak_url"})
+            return Response(err_serializer.data, status=status.HTTP_400_BAD_REQUEST)
 
         process_instances = get_process_instances(zaak_url)
-        serializer = ProcessInstanceSerializer(process_instances, many=True)
+        serializer = self.serializer_class(process_instances, many=True)
 
         return Response(serializer.data)

--- a/backend/src/zac/camunda/tests/test_fetch_process_instances.py
+++ b/backend/src/zac/camunda/tests/test_fetch_process_instances.py
@@ -133,7 +133,7 @@ class ProcessInstanceTests(TestCase):
     def test_fetch_process_instances(self, m_messages, m_task_from, m_request):
         self._setUpMock(m_request)
 
-        url = reverse("camunda:fetch-process-instances")
+        url = reverse("fetch-process-instances")
 
         response = self.client.get(url, {"zaak_url": ZAAK_URL})
 

--- a/backend/src/zac/camunda/urls.py
+++ b/backend/src/zac/camunda/urls.py
@@ -1,7 +1,0 @@
-from django.urls import include, path
-
-from . import api
-
-app_name = "camunda"
-
-urlpatterns = [path("api/camunda/", include(api))]

--- a/backend/src/zac/core/templates/core/zaak_detail.html
+++ b/backend/src/zac/core/templates/core/zaak_detail.html
@@ -204,7 +204,7 @@
                  data-zaak="{{ zaak.url }}"
                  data-can-send-bpmn-messages="{{ can_send_bpmn_messages|yesno:'true,false' }}"
                  data-can-do-usertasks="{{ can_do_usertasks|yesno:'true,false' }}"
-                 data-endpoint="{% url 'camunda:fetch-process-instances' %}?zaak_url={{ zaak.url }}"
+                 data-endpoint="{% url 'fetch-process-instances' %}?zaak_url={{ zaak.url }}"
                  data-claim-task-url="{% url 'core:claim-task' %}"
                  data-send-message-url="{% url 'core:send-message' %}"
                  data-csrftoken="{{ csrf_token }}"

--- a/backend/src/zac/urls.py
+++ b/backend/src/zac/urls.py
@@ -19,7 +19,6 @@ urlpatterns = [
     path("core/", include("zac.core.urls")),
     path("forms/", include("zac.forms.urls")),
     path("contrib/", include("zac.contrib.kadaster.urls")),
-    path("camunda/", include("zac.camunda.urls")),
     path("activities/", include("zac.activities.urls")),
     path("reports/", include("zac.reports.urls")),
 ]

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/keten-processen/keten-processen.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/keten-processen/keten-processen.component.ts
@@ -52,7 +52,7 @@ export class KetenProcessenComponent implements OnInit {
   }
 
   getProcesses(): Observable<any> {
-    const endpoint = encodeURI(`/camunda/api/camunda/fetch-process-instances?zaak_url=${this.zaakUrl}`);
+    const endpoint = encodeURI(`/api/camunda/fetch-process-instances?zaak_url=${this.zaakUrl}`);
     return this.http.get(endpoint);
   }
 


### PR DESCRIPTION
Cleaned up URLs - moved from `/camunda/api/camunda/...` to `/api/camunda` so that all API urls are collected in the `zac.api` package. I've changed the URL in the frontend code for this as well.

Additionally, the possible error responses are now included, the correct success response schema and required input parameters.