### PR TITLE
Ensure all used endpoints are documented

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run tests
         run: |
           python src/manage.py collectstatic --noinput --link
-          coverage run src/manage.py test src -v 3
+          coverage run src/manage.py test src
         env:
           DJANGO_SETTINGS_MODULE: zac.conf.ci
           SECRET_KEY: dummy

--- a/backend/src/zac/api/drf_spectacular/utils.py
+++ b/backend/src/zac/api/drf_spectacular/utils.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from drf_spectacular.plumbing import force_instance
+from drf_spectacular.utils import OpenApiParameter
+from rest_framework import serializers
+
+
+def input_serializer_to_parameters(
+    serializer: serializers.Serializer,
+) -> List[OpenApiParameter]:
+    serializer = force_instance(serializer)
+    parameters = []
+
+    for field in serializer.fields.values():
+        if isinstance(field, serializers.HiddenField):
+            continue
+
+        if isinstance(field, serializers.Serializer):
+            # querystring parameters only accept flat structures
+            continue
+
+        parameter = OpenApiParameter(
+            name=field.field_name,
+            type=str,
+            location=OpenApiParameter.QUERY,
+            required=field.required,
+            description=field.help_text,
+            enum=getattr(field, "choices", None),
+        )
+        parameters.append(parameter)
+
+    return parameters

--- a/backend/src/zac/api/urls.py
+++ b/backend/src/zac/api/urls.py
@@ -19,5 +19,6 @@ urlpatterns = [
     path("dowc/", include("zac.contrib.dowc.urls")),
     path("core/", include("zac.core.api.bff_urls")),
     path("camunda/", include("zac.camunda.api.urls")),
+    path("search/", include("zac.elasticsearch.drf_api.urls")),
     path("", include("zac.notifications.urls")),
 ]

--- a/backend/src/zac/core/api/bff_urls.py
+++ b/backend/src/zac/core/api/bff_urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import (
+    CreateZaakDocumentView,
     CreateZaakRelationView,
     EigenschappenView,
     InformatieObjectTypeListView,
@@ -15,6 +16,7 @@ from .views import (
 )
 
 urlpatterns = [
+    # core zgw
     path(
         "cases/<str:bronorganisatie>/<str:identificatie>",
         ZaakDetailView.as_view(),
@@ -36,6 +38,11 @@ urlpatterns = [
         name="zaak-documents",
     ),
     path(
+        "cases/document",
+        CreateZaakDocumentView.as_view(),
+        name="add-document",
+    ),
+    path(
         "cases/<str:bronorganisatie>/<str:identificatie>/related-cases",
         RelatedZakenView.as_view(),
         name="zaak-related",
@@ -53,6 +60,7 @@ urlpatterns = [
         ZaakObjectsView.as_view(),
         name="zaak-objects",
     ),
+    # meta
     path("zaaktypen", ZaakTypenView.as_view(), name="zaaktypen"),
     path("eigenschappen", EigenschappenView.as_view(), name="eigenschappen"),
     path(

--- a/backend/src/zac/core/api/bff_urls.py
+++ b/backend/src/zac/core/api/bff_urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     CreateZaakRelationView,
     EigenschappenView,
+    InformatieObjectTypeListView,
     RelatedZakenView,
     ZaakDetailView,
     ZaakDocumentsView,
@@ -54,4 +55,9 @@ urlpatterns = [
     ),
     path("zaaktypen", ZaakTypenView.as_view(), name="zaaktypen"),
     path("eigenschappen", EigenschappenView.as_view(), name="eigenschappen"),
+    path(
+        "document-types",
+        InformatieObjectTypeListView.as_view(),
+        name="document-types-list",
+    ),
 ]

--- a/backend/src/zac/core/api/bff_urls.py
+++ b/backend/src/zac/core/api/bff_urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import (
+    CreateZaakRelationView,
     EigenschappenView,
     RelatedZakenView,
     ZaakDetailView,
@@ -37,6 +38,9 @@ urlpatterns = [
         "cases/<str:bronorganisatie>/<str:identificatie>/related-cases",
         RelatedZakenView.as_view(),
         name="zaak-related",
+    ),
+    path(
+        "cases/related-case", CreateZaakRelationView.as_view(), name="add-zaak-relation"
     ),
     path(
         "cases/<str:bronorganisatie>/<str:identificatie>/roles",

--- a/backend/src/zac/core/api/serializers.py
+++ b/backend/src/zac/core/api/serializers.py
@@ -154,10 +154,6 @@ class AddZaakRelationSerializer(serializers.Serializer):
         return data
 
 
-class ZaakIdentificatieSerializer(serializers.Serializer):
-    identificatie = serializers.CharField(required=True)
-
-
 class ZaakSerializer(serializers.Serializer):
     identificatie = serializers.CharField(required=True)
     bronorganisatie = serializers.CharField(required=True)

--- a/backend/src/zac/core/api/tests/test_add_document_permissions.py
+++ b/backend/src/zac/core/api/tests/test_add_document_permissions.py
@@ -22,7 +22,7 @@ CATALOGI_ROOT = "https://open-zaak.nl/catalogi/api/v1/"
 
 
 class AddDocumentPermissionTests(ClearCachesMixin, APITransactionTestCase):
-    endpoint = reverse_lazy("core:add-document")
+    endpoint = reverse_lazy("add-document")
 
     def setUp(self):
         super().setUp()

--- a/backend/src/zac/core/api/tests/test_add_zaak_relations.py
+++ b/backend/src/zac/core/api/tests/test_add_zaak_relations.py
@@ -262,7 +262,7 @@ class CreateZakenRelationTests(ClearCachesMixin, APITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_valid_request_without_permissions_to_relate(self, m):
         user = UserFactory.create()

--- a/backend/src/zac/core/api/tests/test_add_zaak_relations.py
+++ b/backend/src/zac/core/api/tests/test_add_zaak_relations.py
@@ -17,7 +17,7 @@ from zac.tests.utils import paginated_response
 
 @requests_mock.Mocker()
 class GetZakenTests(ESMixin, ClearCachesMixin, APITransactionTestCase):
-    endpoint = reverse_lazy("core:zaken-search")
+    endpoint = reverse_lazy("zaken-search")
 
     def test_login_required(self, m):
         response = self.client.get(self.endpoint)

--- a/backend/src/zac/core/api/tests/test_add_zaak_relations.py
+++ b/backend/src/zac/core/api/tests/test_add_zaak_relations.py
@@ -135,7 +135,7 @@ class GetZakenTests(ESMixin, ClearCachesMixin, APITransactionTestCase):
 
 @requests_mock.Mocker()
 class CreateZakenRelationTests(ClearCachesMixin, APITestCase):
-    endpoint = reverse_lazy("core:add-zaak-relation")
+    endpoint = reverse_lazy("add-zaak-relation")
 
     def test_login_required(self, m):
         response = self.client.post(self.endpoint)

--- a/backend/src/zac/core/api/urls.py
+++ b/backend/src/zac/core/api/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from .views import (
     AddDocumentView,
-    AddZaakRelationView,
     GetDocumentInfoView,
     GetInformatieObjectTypenView,
     PostExtraInfoSubjectView,
@@ -20,7 +19,6 @@ urlpatterns = [
         name="add-document",
     ),
     path("documents/info", GetDocumentInfoView.as_view(), name="get-document-info"),
-    path("zaken_relation", AddZaakRelationView.as_view(), name="add-zaak-relation"),
     path(
         "betrokkene/info",
         PostExtraInfoSubjectView.as_view(),

--- a/backend/src/zac/core/api/urls.py
+++ b/backend/src/zac/core/api/urls.py
@@ -5,7 +5,6 @@ from .views import (
     AddZaakRelationView,
     GetDocumentInfoView,
     GetInformatieObjectTypenView,
-    GetZakenView,
     PostExtraInfoSubjectView,
 )
 
@@ -22,7 +21,6 @@ urlpatterns = [
     ),
     path("documents/info", GetDocumentInfoView.as_view(), name="get-document-info"),
     path("zaken_relation", AddZaakRelationView.as_view(), name="add-zaak-relation"),
-    path("zaken_search", GetZakenView.as_view(), name="zaken-search"),
     path(
         "betrokkene/info",
         PostExtraInfoSubjectView.as_view(),

--- a/backend/src/zac/core/api/urls.py
+++ b/backend/src/zac/core/api/urls.py
@@ -1,13 +1,8 @@
 from django.urls import path
 
-from .views import AddDocumentView, GetDocumentInfoView, PostExtraInfoSubjectView
+from .views import GetDocumentInfoView, PostExtraInfoSubjectView
 
 urlpatterns = [
-    path(
-        "documents/upload",
-        AddDocumentView.as_view(),
-        name="add-document",
-    ),
     path("documents/info", GetDocumentInfoView.as_view(), name="get-document-info"),
     path(
         "betrokkene/info",

--- a/backend/src/zac/core/api/urls.py
+++ b/backend/src/zac/core/api/urls.py
@@ -1,18 +1,8 @@
 from django.urls import path
 
-from .views import (
-    AddDocumentView,
-    GetDocumentInfoView,
-    GetInformatieObjectTypenView,
-    PostExtraInfoSubjectView,
-)
+from .views import AddDocumentView, GetDocumentInfoView, PostExtraInfoSubjectView
 
 urlpatterns = [
-    path(
-        "documents/get-informatieobjecttypen",
-        GetInformatieObjectTypenView.as_view(),
-        name="get-informatieobjecttypen",
-    ),
     path(
         "documents/upload",
         AddDocumentView.as_view(),

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -380,7 +380,15 @@ class ZaakObjectsView(GetZaakMixin, views.APIView):
         return Response(serializer.data)
 
 
+@extend_schema(summary=_("List zaaktypen"), tags=["meta"])
 class ZaakTypenView(ListAPIView):
+    """
+    List a collection of zaaktypen available to the end user.
+
+    Different versions of the same zaaktype are aggregated. Only the zaaktypen that
+    the authenticated user has read-permissions for are returned.
+    """
+
     authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = ZaakTypeAggregateSerializer
@@ -414,7 +422,19 @@ class ZaakTypenView(ListAPIView):
         return zaaktypen_aggregated
 
 
+@extend_schema(summary=_("List zaaktype eigenschappen"), tags=["meta"])
 class EigenschappenView(ListAPIView):
+    """
+    List the available eigenschappen for a given zaaktype.
+
+    Given the `zaaktype_omschrijving`, all versions of the matching zaaktype are
+    considered. Returns the eigenschappen available for the aggregated set of zaaktype
+    versions.
+
+    Note that only the zaaktypen that the authenticated user has read-permissions for
+    are considered.
+    """
+
     authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = SearchEigenschapSerializer

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -21,7 +21,6 @@ from zgw_consumers.models import Service
 from zac.accounts.permissions import UserPermissions
 from zac.contrib.brp.api import fetch_extrainfo_np
 from zac.contrib.kownsl.api import get_review_requests, retrieve_advices
-from zac.elasticsearch.searches import autocomplete_zaak_search
 from zac.utils.filters import ApiFilterBackend
 
 from ..cache import invalidate_zaak_cache
@@ -60,9 +59,7 @@ from .serializers import (
     ZaakDetailSerializer,
     ZaakDocumentSerializer,
     ZaakEigenschapSerializer,
-    ZaakIdentificatieSerializer,
     ZaakObjectGroupSerializer,
-    ZaakSerializer,
     ZaakStatusSerializer,
     ZaakTypeAggregateSerializer,
 )
@@ -235,20 +232,6 @@ class AddZaakRelationView(views.APIView):
         invalidate_zaak_cache(factory(Zaak, main_zaak))
 
         return Response(status=status.HTTP_200_OK)
-
-
-class GetZakenView(views.APIView):
-    permission_classes = (permissions.IsAuthenticated,)
-    schema = None
-
-    def get(self, request: Request) -> Response:
-        serializer = ZaakIdentificatieSerializer(data=request.query_params)
-        serializer.is_valid(raise_exception=True)
-        zaken = autocomplete_zaak_search(
-            identificatie=serializer.validated_data["identificatie"]
-        )
-        zaak_serializer = ZaakSerializer(instance=zaken, many=True)
-        return Response(data=zaak_serializer.data)
 
 
 # Backend-For-Frontend endpoints (BFF)

--- a/backend/src/zac/elasticsearch/drf_api/serializers.py
+++ b/backend/src/zac/elasticsearch/drf_api/serializers.py
@@ -1,0 +1,14 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import serializers
+
+
+class ZaakIdentificatieSerializer(serializers.Serializer):
+    identificatie = serializers.CharField(
+        required=True,
+        label=_("zaak identification"),
+        help_text=_(
+            "Enter a (part) of the zaak identification you wish to "
+            "find, case insensitive."
+        ),
+    )

--- a/backend/src/zac/elasticsearch/drf_api/urls.py
+++ b/backend/src/zac/elasticsearch/drf_api/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import GetZakenView
+
+urlpatterns = [
+    path("zaken/autocomplete", GetZakenView.as_view(), name="zaken-search"),
+]

--- a/backend/src/zac/elasticsearch/drf_api/views.py
+++ b/backend/src/zac/elasticsearch/drf_api/views.py
@@ -1,0 +1,36 @@
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import permissions, views
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from zac.api.drf_spectacular.utils import input_serializer_to_parameters
+from zac.core.api.serializers import ZaakSerializer
+
+from ..searches import autocomplete_zaak_search
+from .serializers import ZaakIdentificatieSerializer
+
+
+class GetZakenView(views.APIView):
+    permission_classes = (permissions.IsAuthenticated,)
+
+    @staticmethod
+    def get_serializer(**kwargs):
+        return ZaakSerializer(many=True, **kwargs)
+
+    @extend_schema(
+        summary=_("Autocomplete search zaken"),
+        parameters=input_serializer_to_parameters(ZaakIdentificatieSerializer),
+    )
+    def get(self, request: Request) -> Response:
+        """
+        Retrieve a list of zaken based on autocomplete search.
+        """
+        serializer = ZaakIdentificatieSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        zaken = autocomplete_zaak_search(
+            identificatie=serializer.validated_data["identificatie"]
+        )
+        zaak_serializer = self.get_serializer(instance=zaken)
+        return Response(data=zaak_serializer.data)

--- a/backend/src/zac/js/components/documents/AddDocument.js
+++ b/backend/src/zac/js/components/documents/AddDocument.js
@@ -12,7 +12,7 @@ import { Select } from '../forms/Select';
 import { SubmitRow } from '../forms/Utils';
 
 
-const ENDPOINT_UPLOAD = '/core/api/documents/upload';
+const ENDPOINT_UPLOAD = '/api/core/cases/document';
 const ENDPOINT_GET_ZIO = '/api/core/document-types';
 
 

--- a/backend/src/zac/js/components/documents/AddDocument.js
+++ b/backend/src/zac/js/components/documents/AddDocument.js
@@ -13,7 +13,7 @@ import { SubmitRow } from '../forms/Utils';
 
 
 const ENDPOINT_UPLOAD = '/core/api/documents/upload';
-const ENDPOINT_GET_ZIO = '/core/api/documents/get-informatieobjecttypen';
+const ENDPOINT_GET_ZIO = '/api/core/document-types';
 
 
 const initialState = {

--- a/backend/src/zac/js/views/zaak-detail/AddZaakRelation.js
+++ b/backend/src/zac/js/views/zaak-detail/AddZaakRelation.js
@@ -11,7 +11,7 @@ import {Label} from '../../components/forms/Label';
 import {Help} from '../../components/forms/Help';
 
 const ENDPOINT_ADD_RELATION = '/core/api/zaken_relation';
-const ENDPOINT_ZAKEN = '/core/api/zaken_search';
+const ENDPOINT_ZAKEN = '/api/search/zaken/autocomplete';
 
 const initialState = {
     errors: '',

--- a/backend/src/zac/js/views/zaak-detail/AddZaakRelation.js
+++ b/backend/src/zac/js/views/zaak-detail/AddZaakRelation.js
@@ -10,7 +10,7 @@ import {AARD_RELATIES} from '../../constants';
 import {Label} from '../../components/forms/Label';
 import {Help} from '../../components/forms/Help';
 
-const ENDPOINT_ADD_RELATION = '/core/api/zaken_relation';
+const ENDPOINT_ADD_RELATION = '/api/core/cases/related-case';
 const ENDPOINT_ZAKEN = '/api/search/zaken/autocomplete';
 
 const initialState = {


### PR DESCRIPTION
Added the following views to the API documentation

* list document types
* upload zaak-document
* create related zaak relation
* autocomplete search zaken based on identificatie

Additionally, included some more schema documentation for the search endpoints.

The schema tags are now set up so that:

* `search` groups endpoints dealing with search/autocomplete/...
* `meta` deals with catalogi API related endpoints (zaaktypen, eigenschappen, documenttypes)
* `core` deals with zaken/documenten (read & write)

@kelvincy be advised that some URLs have been refactored here:

- `/core/api/documents/upload` -> `/api/core/cases/document`
- `/core/api/documents/get-informatieobjecttypen` -> `/api/core/document-types`
- `/core/api/zaken_relation` -> `/api/core/cases/related-case`
- `/core/api/zaken_search` -> `/api/search/zaken/autocomplete`