### PR TITLE
Added dynamic form context to user task endpoint - api docs not worki…

### DIFF
--- a/backend/src/zac/camunda/api/serializers.py
+++ b/backend/src/zac/camunda/api/serializers.py
@@ -3,6 +3,8 @@ from typing import List
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
+from zgw_consumers.api_models.zaken import Zaak
+from zgw_consumers.drf.serializers import APIModelSerializer
 
 from zac.accounts.serializers import UserSerializer
 from zac.api.polymorphism import PolymorphicSerializer
@@ -83,3 +85,16 @@ class MessageSerializer(serializers.Serializer):
 
     def set_message_choices(self, message_names: List[str]):
         self.fields["message"].choices = [(name, name) for name in message_names]
+
+
+class TaskZaakInformatieSerializer(APIModelSerializer):
+    """
+    TODO: Write tests
+    """
+
+    class Meta:
+        model = Zaak
+        fields = (
+            "omschrijving",
+            "toelichting",
+        )

--- a/backend/src/zac/camunda/apps.py
+++ b/backend/src/zac/camunda/apps.py
@@ -5,4 +5,5 @@ class CamundaConfig(AppConfig):
     name = "zac.camunda"
 
     def ready(self):
+        from . import dynamic_forms
         from .user_tasks import redirects  # noqa

--- a/backend/src/zac/camunda/dynamic_forms/__init__.py
+++ b/backend/src/zac/camunda/dynamic_forms/__init__.py
@@ -1,11 +1,14 @@
-from .data import FormField
+from .context import get_context
+from .data import DynamicFormContext, FormField
 from .drf import form_field_context_serializer
 from .form_field import FormFieldContext, get_form_field_context, register_input_type
-
-__all__ = [
-    "register_input_type",
-    "FormFieldContext",
-    "get_form_field_context",
-    "FormField",
-    "form_field_context_serializer",
-]
+from .serializers import (
+    BooleanFieldSerializer,
+    ChoiceFieldContextSerializer,
+    DateTimeFieldSerializer,
+    DynamicFormContextSerializer,
+    DynamicFormFieldSerializer,
+    IntFieldSerializer,
+    StringFieldSerializer,
+    get_form_field_context,
+)

--- a/backend/src/zac/camunda/dynamic_forms/__init__.py
+++ b/backend/src/zac/camunda/dynamic_forms/__init__.py
@@ -1,0 +1,11 @@
+from .data import FormField
+from .drf import form_field_context_serializer
+from .form_field import FormFieldContext, get_form_field_context, register_input_type
+
+__all__ = [
+    "register_input_type",
+    "FormFieldContext",
+    "get_form_field_context",
+    "FormField",
+    "form_field_context_serializer",
+]

--- a/backend/src/zac/camunda/dynamic_forms/context.py
+++ b/backend/src/zac/camunda/dynamic_forms/context.py
@@ -1,0 +1,70 @@
+from typing import List, Optional
+from xml.etree.ElementTree import Element
+
+from django_camunda.bpmn import CAMUNDA_NS
+
+from zac.core.camunda import get_process_zaak_url
+from zac.core.services import fetch_zaaktype, get_zaak
+
+from ..bpmn import get_bpmn
+from ..data import Task
+from ..process_instances import get_process_instance
+from ..user_tasks.context import register
+from .data import DynamicFormContext, FormField
+from .form_field import get_form_field_context
+from .serializers import DynamicFormContextSerializer
+
+
+def get_form_fields_from_task(task) -> Optional[List[Element]]:
+    """
+    Retrieve form fields from camunda task.
+    """
+    tree = get_bpmn(task.process_definition_id)
+    task_id = task.task_definition_key
+    task_definition = tree.find(f".//bpmn:userTask[@id='{task_id}']", CAMUNDA_NS)
+    form_fields = task_definition.findall(".//camunda:formField", CAMUNDA_NS)
+    return form_fields
+
+
+def get_form_fields(task_form_fields) -> Optional[List[FormField]]:
+    form_fields = []
+    for definition in task_form_fields or []:
+        input_type = definition.attrib["type"]
+        default = definition.attrib.get("defaultValue")
+        kwargs = {"value": default}
+        if input_type == "enum":
+            kwargs["choices"] = [
+                (value.attrib["id"], value.attrib["name"])
+                for value in definition.getchildren()
+            ]
+
+        form_fields.append(
+            FormField(
+                name=definition.attrib["id"],
+                label=definition.attrib.get("label", ""),
+                input_type=input_type,
+                form_field_context=get_form_field_context(input_type, **kwargs),
+            )
+        )
+    return form_fields
+
+
+@register("zac:dynamicForm", DynamicFormContextSerializer)
+def get_context(task: Task) -> DynamicFormContext:
+    # TODO: Write tests.
+
+    # Get zaak and construct title
+    process_instance = get_process_instance(task.process_instance_id)
+    zaak_url = get_process_zaak_url(process_instance)
+    zaak = get_zaak(zaak_url=zaak_url)
+    zaaktype = fetch_zaaktype(zaak.zaaktype)
+    title = f"{zaaktype.omschrijving} - {zaaktype.versiedatum}"
+
+    # task_form_fields = get_form_fields_from_task(task)
+    # form_fields = get_form_fields(task_form_fields)
+
+    return DynamicFormContext(
+        title=title,
+        zaak_informatie=zaak,
+        # form_fields=form_fields,
+    )

--- a/backend/src/zac/camunda/dynamic_forms/context.py
+++ b/backend/src/zac/camunda/dynamic_forms/context.py
@@ -60,11 +60,11 @@ def get_context(task: Task) -> DynamicFormContext:
     zaaktype = fetch_zaaktype(zaak.zaaktype)
     title = f"{zaaktype.omschrijving} - {zaaktype.versiedatum}"
 
-    # task_form_fields = get_form_fields_from_task(task)
-    # form_fields = get_form_fields(task_form_fields)
+    task_form_fields = get_form_fields_from_task(task)
+    form_fields = get_form_fields(task_form_fields)
 
     return DynamicFormContext(
         title=title,
         zaak_informatie=zaak,
-        # form_fields=form_fields,
+        form_fields=form_fields,
     )

--- a/backend/src/zac/camunda/dynamic_forms/data.py
+++ b/backend/src/zac/camunda/dynamic_forms/data.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+from zgw_consumers.api_models.zaken import Zaak
+
+from .form_field import FormFieldContext
+
+
+@dataclass
+class BooleanField:
+    value: bool
+
+
+@dataclass
+class DateTimeField:
+    value: datetime
+
+
+@dataclass
+class IntField:
+    value: int
+
+
+@dataclass
+class StringField:
+    value: str
+
+
+@dataclass
+class ChoiceField(StringField):
+    choices: List[str]
+
+
+@dataclass
+class FormField:
+    name: str
+    label: str
+    input_type: str
+    form_field_context: FormFieldContext
+
+
+@dataclass
+class DynamicFormContext:
+    title: str
+    zaak_informatie: Zaak
+    form_fields: List[FormField]

--- a/backend/src/zac/camunda/dynamic_forms/data.py
+++ b/backend/src/zac/camunda/dynamic_forms/data.py
@@ -37,7 +37,7 @@ class FormField:
     name: str
     label: str
     input_type: str
-    form_field_context: FormFieldContext
+    context: FormFieldContext
 
 
 @dataclass

--- a/backend/src/zac/camunda/dynamic_forms/drf.py
+++ b/backend/src/zac/camunda/dynamic_forms/drf.py
@@ -1,0 +1,37 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework.utils import formatting
+from zgw_consumers.drf.serializers import APIModelSerializer
+
+from zac.api.polymorphism import SerializerCls
+
+
+def form_field_context_serializer(serializer_cls: SerializerCls) -> SerializerCls:
+    """
+    Ensure that the FormFieldContext-specific serializer is wrapped in a FormField serializer.
+
+    The decorator enforces the same label/help_text and meta-information for the API
+    schema documentation.
+    """
+    from .data import FormField
+
+    name = serializer_cls.__name__
+    name = formatting.remove_trailing_string(name, "Serializer")
+    name = formatting.remove_trailing_string(name, "Field")
+
+    class FormFieldSerializer(APIModelSerializer):
+        form_field_context = serializer_cls(
+            label=_("Form Field Context"),
+            help_text=_(
+                "The form field shape depends on the `input_type` property. The value will be "
+                "`null` if the backend does not 'know' the form field `input_type`."
+            ),
+            allow_null=True,
+        )
+
+        class Meta:
+            model = FormField
+            fields = ("form_field_context",)
+
+    name = f"{name}FormFieldSerializer"
+    return type(name, (FormFieldSerializer,), {})

--- a/backend/src/zac/camunda/dynamic_forms/drf.py
+++ b/backend/src/zac/camunda/dynamic_forms/drf.py
@@ -20,18 +20,15 @@ def form_field_context_serializer(serializer_cls: SerializerCls) -> SerializerCl
     name = formatting.remove_trailing_string(name, "Field")
 
     class FormFieldSerializer(APIModelSerializer):
-        form_field_context = serializer_cls(
+        context = serializer_cls(
             label=_("Form Field Context"),
-            help_text=_(
-                "The form field shape depends on the `input_type` property. The value will be "
-                "`null` if the backend does not 'know' the form field `input_type`."
-            ),
+            help_text=_("The form field shape depends on the `input_type` property."),
             allow_null=True,
         )
 
         class Meta:
             model = FormField
-            fields = ("form_field_context",)
+            fields = ("context",)
 
     name = f"{name}FormFieldSerializer"
     return type(name, (FormFieldSerializer,), {})

--- a/backend/src/zac/camunda/dynamic_forms/form_field.py
+++ b/backend/src/zac/camunda/dynamic_forms/form_field.py
@@ -50,7 +50,6 @@ def register_input_type(input_type: str, serializer_cls: Type[serializers.Serial
 
     def decorator(func: callable):
         if input_type in REGISTRY_INPUT_TYPES:
-            print(REGISTRY_INPUT_TYPES)
             warnings.warn(
                 f"Overwriting existing input type '{input_type}' in registry.",
                 DuplicateInputTypeWarning,

--- a/backend/src/zac/camunda/dynamic_forms/form_field.py
+++ b/backend/src/zac/camunda/dynamic_forms/form_field.py
@@ -33,7 +33,7 @@ def get_form_field_context(input_type: str, **kwargs) -> Optional[FormFieldConte
     ``REGISTRY`` constant and registering their input_type key with the appropriate callback
     callable.
     """
-    (callback, *rest) = REGISTRY_INPUT_TYPES.get(f"zac:form_field:{input_type}")
+    (callback, *rest) = REGISTRY_INPUT_TYPES.get(input_type)
     if callback is None:
         return None
     return callback(input_type, **kwargs)

--- a/backend/src/zac/camunda/dynamic_forms/form_field.py
+++ b/backend/src/zac/camunda/dynamic_forms/form_field.py
@@ -1,0 +1,65 @@
+import functools
+import warnings
+from abc import ABC
+from typing import Dict, Optional, Tuple, Type
+
+from rest_framework import serializers
+
+from zac.api.polymorphism import SerializerCls
+
+from ..data import Task
+
+REGISTRY_INPUT_TYPES: Dict[str, Tuple[callable, SerializerCls]] = {}
+
+
+class FormFieldContext(ABC):
+    """
+    Base class for form field context.
+
+    The form field subclass is determined by the input_type.
+    """
+
+    pass
+
+
+def get_form_field_context(input_type: str, **kwargs) -> Optional[FormFieldContext]:
+    """
+    Retrieve the form field specific context for a given form field.
+
+    Consult the registry mapping form keys to specific context-determination functions.
+    If no callback exists for a given input_type key, ``None`` is returned.
+
+    Third party or non-core apps can add input_type keys to the registry by importing the
+    ``REGISTRY`` constant and registering their input_type key with the appropriate callback
+    callable.
+    """
+    (callback, *rest) = REGISTRY_INPUT_TYPES.get(f"zac:form_field:{input_type}")
+    if callback is None:
+        return None
+    return callback(input_type, **kwargs)
+
+
+class DuplicateInputTypeWarning(Warning):
+    pass
+
+
+def register_input_type(input_type: str, serializer_cls: Type[serializers.Serializer]):
+    """
+    Register the form key with the given callback and serializer class.
+    """
+
+    def decorator(func: callable):
+        if input_type in REGISTRY_INPUT_TYPES:
+            print(REGISTRY_INPUT_TYPES)
+            warnings.warn(
+                f"Overwriting existing input type '{input_type}' in registry.",
+                DuplicateInputTypeWarning,
+            )
+
+        REGISTRY_INPUT_TYPES[input_type] = (func, serializer_cls)
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+    return decorator

--- a/backend/src/zac/camunda/dynamic_forms/serializers.py
+++ b/backend/src/zac/camunda/dynamic_forms/serializers.py
@@ -59,14 +59,14 @@ class DynamicFormContextSerializer(APIModelSerializer):
 
     title = serializers.CharField()
     zaak_informatie = TaskZaakInformatieSerializer(label=_("Case summary"))
-    # form_fields = DynamicFormFieldSerializer(many=True)
+    form_fields = DynamicFormFieldSerializer(many=True)
 
     class Meta:
         model = DynamicFormContext
         fields = (
             "title",
             "zaak_informatie",
-            # "form_fields",
+            "form_fields",
         )
 
 

--- a/backend/src/zac/camunda/dynamic_forms/serializers.py
+++ b/backend/src/zac/camunda/dynamic_forms/serializers.py
@@ -1,0 +1,126 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import serializers
+from zgw_consumers.drf.serializers import APIModelSerializer
+
+from zac.api.polymorphism import PolymorphicSerializer
+
+from ..api.serializers import TaskZaakInformatieSerializer
+from ..user_tasks.context import usertask_context_serializer
+from .data import (
+    BooleanField,
+    ChoiceField,
+    DateTimeField,
+    DynamicFormContext,
+    FormFieldContext,
+    IntField,
+    StringField,
+)
+from .drf import form_field_context_serializer
+from .form_field import REGISTRY_INPUT_TYPES, register_input_type
+
+
+class DynamicFormFieldSerializer(PolymorphicSerializer):
+    discriminator_field = "input_type"
+    serializer_mapping = {}  # set at run-time based on the REGISTRY
+
+    input_type = serializers.ChoiceField(
+        label=_("Input type for form field"),
+        source="formfield.input_type",
+        help_text=_(
+            "The input type of the form field to render. Note that unknown input type keys (= not "
+            "present in the enum) will be returned as is."
+        ),
+        allow_blank=True,
+        choices=(),
+    )
+
+    name = serializers.CharField()
+    label = serializers.CharField()
+    # the form_field_context is added by the serializer_mapping serializers
+
+    def __init__(self, *args, **kwargs):
+
+        self.serializer_mapping = {
+            form_key: serializer
+            for form_key, (callback, serializer) in REGISTRY_INPUT_TYPES.items()
+        }
+
+        super().__init__(*args, **kwargs)
+
+        self.fields["input_type"].choices = list(REGISTRY_INPUT_TYPES.keys())
+
+
+@usertask_context_serializer
+class DynamicFormContextSerializer(APIModelSerializer):
+    """
+    TODO: Write tests
+    """
+
+    title = serializers.CharField()
+    zaak_informatie = TaskZaakInformatieSerializer(label=_("Case summary"))
+    # form_fields = DynamicFormFieldSerializer(many=True)
+
+    class Meta:
+        model = DynamicFormContext
+        fields = (
+            "title",
+            "zaak_informatie",
+            # "form_fields",
+        )
+
+
+@form_field_context_serializer
+class BooleanFieldSerializer(APIModelSerializer):
+    class Meta:
+        model = BooleanField
+        fields = ("value",)
+
+
+@form_field_context_serializer
+class DateTimeFieldSerializer(APIModelSerializer):
+    class Meta:
+        model = DateTimeField
+        fields = ("value",)
+
+
+@form_field_context_serializer
+class IntFieldSerializer(APIModelSerializer):
+    class Meta:
+        model = IntField
+        fields = ("value",)
+
+
+@form_field_context_serializer
+class StringFieldSerializer(APIModelSerializer):
+    class Meta:
+        model = StringField
+        fields = ("value",)
+
+
+@form_field_context_serializer
+class ChoiceFieldContextSerializer(APIModelSerializer):
+    class Meta:
+        model = ChoiceField
+        fields = (
+            "value",
+            "choices",
+        )
+
+
+INPUT_TYPE_FIELD_MAPPING = {
+    "boolean": BooleanField,
+    "date": DateTimeField,
+    "long": IntField,
+    "string": StringField,
+    "enum": ChoiceField,
+}
+
+
+@register_input_type("zac:form_field:boolean", BooleanFieldSerializer)
+@register_input_type("zac:form_field:date", DateTimeFieldSerializer)
+@register_input_type("zac:form_field:long", IntFieldSerializer)
+@register_input_type("zac:form_field:string", StringFieldSerializer)
+@register_input_type("zac:form_field:enum", ChoiceFieldContextSerializer)
+def get_form_field_context(input_type: str, **kwargs):
+    return INPUT_TYPE_FIELD_MAPPING[input_type](**kwargs)

--- a/backend/src/zac/camunda/user_tasks/context.py
+++ b/backend/src/zac/camunda/user_tasks/context.py
@@ -34,7 +34,7 @@ def get_context(task: Task) -> Optional[Context]:
     ``REGISTRY`` constant and registering their form key with the appropriote callback
     callable.
     """
-    (callback, *rest) = REGISTRY.get(task.form_key)
+    (callback, *rest) = REGISTRY.get(task.form_key, "zac:dynamic_form")
     if callback is None:
         return None
     return callback(task)

--- a/backend/src/zac/camunda/user_tasks/context.py
+++ b/backend/src/zac/camunda/user_tasks/context.py
@@ -34,7 +34,7 @@ def get_context(task: Task) -> Optional[Context]:
     ``REGISTRY`` constant and registering their form key with the appropriote callback
     callable.
     """
-    (callback, *rest) = REGISTRY.get(task.form_key, "zac:dynamic_form")
+    (callback, *rest) = REGISTRY.get(task.form_key, "zac:dynamicForm")
     if callback is None:
         return None
     return callback(task)

--- a/backend/src/zac/contrib/kownsl/camunda.py
+++ b/backend/src/zac/contrib/kownsl/camunda.py
@@ -9,6 +9,7 @@ from zgw_consumers.api_models.documenten import Document
 from zgw_consumers.api_models.zaken import Zaak
 from zgw_consumers.drf.serializers import APIModelSerializer
 
+from zac.camunda.api.serializers import TaskZaakInformatieSerializer
 from zac.camunda.data import Task
 from zac.camunda.process_instances import get_process_instance
 from zac.camunda.user_tasks import Context, register, usertask_context_serializer
@@ -24,16 +25,6 @@ class AdviceApprovalContext(Context):
     title: str
     zaak: Zaak
     documents: List[Document]
-
-
-class ZaakInformatieTaskSerializer(APIModelSerializer):
-    # TODO: Write tests.
-    class Meta:
-        model = Zaak
-        fields = (
-            "omschrijving",
-            "toelichting",
-        )
 
 
 class DocumentUserTaskSerializer(APIModelSerializer):
@@ -69,7 +60,7 @@ class DocumentUserTaskSerializer(APIModelSerializer):
 class AdviceApprovalContextSerializer(APIModelSerializer):
     # TODO: Write tests.
     documents = DocumentUserTaskSerializer(many=True)
-    zaak_informatie = ZaakInformatieTaskSerializer()
+    zaak_informatie = TaskZaakInformatieSerializer()
 
     class Meta:
         model = AdviceApprovalContext


### PR DESCRIPTION
…ng yet.

Part of the dynamic forms will return a different value than the other ones. Think of "enum" input_type, but also data validation and expected data is different based on input_type. That could be handled internally without explicitly exposing that, of course, but that's not as neat. (see ZaakRevReqDetailSerializer for example) 

Not sure if I should continue down this path. I thought it'd be nice if all values get validated by their respective serializers and the API docs would kick back the appropriate data type instead of just generic data. 

@sergei-maertens:
Okay, got it to semi-work. On the redocs page you can't change the inputType yet. Would you have a clue? I'm guessing it has to do with the way the nested serializer is detailed in the schema.