### PR TITLE
Integrate dynamic forms

### DIFF
--- a/backend/src/zac/api/drf_spectacular/polymorphic.py
+++ b/backend/src/zac/api/drf_spectacular/polymorphic.py
@@ -1,5 +1,5 @@
 from drf_spectacular.extensions import OpenApiSerializerExtension
-from drf_spectacular.plumbing import ResolvedComponent
+from drf_spectacular.plumbing import ResolvedComponent, build_object_type
 
 from ..polymorphism import PolymorphicSerializer
 
@@ -36,8 +36,21 @@ class PolymorphicSerializerExtension(OpenApiSerializerExtension):
             sub_serializer,
         ) in serializer.serializer_mapping.items():
             resolved = auto_schema.resolve_serializer(sub_serializer, direction)
+
             if not resolved.name:
-                continue
+                # serializer didn't have any declared properties
+                generic = ResolvedComponent(
+                    name="GenericObject",
+                    type=ResolvedComponent.SCHEMA,
+                    object=sub_serializer,
+                )
+                generic.schema = build_object_type(
+                    description="Generic object",
+                    additionalProperties=True,  # displays 'property name * - any' in ReDoc
+                )
+                auto_schema.registry.register_on_missing(generic)
+                resolved = generic
+
             combined = ResolvedComponent(
                 name=f"{base_name}{resolved.name}",
                 type=ResolvedComponent.SCHEMA,

--- a/backend/src/zac/camunda/dynamic_forms/context.py
+++ b/backend/src/zac/camunda/dynamic_forms/context.py
@@ -53,23 +53,3 @@ def get_context(task: Task) -> DynamicFormContext:
     formfields = extract_task_form_fields(task) or []
     form_fields = [get_field_definition(field) for field in formfields]
     return DynamicFormContext(form_fields=form_fields)
-
-
-def build_dynamic_form_serializer(task: Task, **kwargs) -> DynamicFormWriteSerializer:
-    from ..forms import extract_task_form_fields
-
-    formfields = extract_task_form_fields(task) or []
-
-    fields = {}
-    for field in formfields:
-        field_type = field.attrib["type"]
-        field_definition = get_field_definition(field)
-        field_cls, get_kwargs = FIELD_TYPE_MAP[field_type]
-        name = field_definition.pop("name")
-        fields[name] = field_cls(**get_kwargs(field_definition))
-
-    Serializer = type(
-        "DynamicFormWriteSerializer", (DynamicFormWriteSerializer,), fields
-    )
-
-    return Serializer(**kwargs)

--- a/backend/src/zac/camunda/dynamic_forms/serializers.py
+++ b/backend/src/zac/camunda/dynamic_forms/serializers.py
@@ -156,10 +156,12 @@ class DynamicFormWriteSerializer(serializers.Serializer):
         """
         Inject the derived serializer fields from the task form definition.
         """
-        task = kwargs["context"]["task"]
-
         serializer = super().__new__(cls, *args, **kwargs)
 
+        if "context" not in kwargs or "task" not in kwargs["context"]:
+            return serializer
+
+        task = kwargs["context"]["task"]
         fields = BindingDict(serializer)
         for key, value in get_dynamic_form_serializer_fields(task).items():
             fields[key] = value

--- a/backend/src/zac/camunda/tests/test_dynamic_forms_task_context.py
+++ b/backend/src/zac/camunda/tests/test_dynamic_forms_task_context.py
@@ -198,55 +198,55 @@ class DynamicFormTests(ClearCachesMixin, APITestCase):
         ]
         self.assertEqual(data["context"]["formFields"], expected_formfields)
 
-    # @requests_mock.Mocker()
-    # def test_submit_form_data_ok(self, m):
-    #     self.mock_get_task.return_value = self._get_task()
-    #     mock_bpmn_response(m, FILES_DIR / "dynamic-form.bpmn")
-    #     data = {
-    #         "stringField": "Some string",
-    #         "intField": 42,
-    #         "boolField": True,
-    #         "dateField": "2021-02-09T00:00Z",
-    #         "enumField": "second",
-    #     }
+    @requests_mock.Mocker()
+    def test_submit_form_data_ok(self, m):
+        self.mock_get_task.return_value = self._get_task()
+        mock_bpmn_response(m, FILES_DIR / "dynamic-form.bpmn")
+        data = {
+            "stringField": "Some string",
+            "intField": 42,
+            "boolField": True,
+            "dateField": "2021-02-09T00:00Z",
+            "enumField": "second",
+        }
 
-    #     with patch("zac.camunda.api.views.complete_task") as mock_complete:
-    #         response = self.client.put(self.endpoint, data)
+        with patch("zac.camunda.api.views.complete_task") as mock_complete:
+            response = self.client.put(self.endpoint, data)
 
-    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
-    #     mock_complete.assert_called_once_with(
-    #         uuid.UUID("598347ee-62fc-46a2-913a-6e0788bc1b8c"),
-    #         {
-    #             "bptlAppId": "",
-    #             "stringField": "Some string",
-    #             "intField": 42,
-    #             "boolField": True,
-    #             "dateField": datetime.fromisoformat("2021-02-09T00:00:00+00:00"),
-    #             "enumField": "second",
-    #         },
-    #     )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        mock_complete.assert_called_once_with(
+            uuid.UUID("598347ee-62fc-46a2-913a-6e0788bc1b8c"),
+            {
+                "bptlAppId": "",
+                "stringField": "Some string",
+                "intField": 42,
+                "boolField": True,
+                "dateField": datetime.fromisoformat("2021-02-09T00:00:00+00:00"),
+                "enumField": "second",
+            },
+        )
 
-    # @requests_mock.Mocker()
-    # def test_submit_form_data_validation_errors(self, m):
-    #     self.mock_get_task.return_value = self._get_task()
-    #     mock_bpmn_response(m, FILES_DIR / "dynamic-form.bpmn")
-    #     data = {
-    #         "stringField": "",
-    #         "intField": "not-an-int",
-    #         "boolField": "not-a-bool",
-    #         "dateField": "not-a-timestamp",
-    #         "enumField": "third",
-    #     }
+    @requests_mock.Mocker()
+    def test_submit_form_data_validation_errors(self, m):
+        self.mock_get_task.return_value = self._get_task()
+        mock_bpmn_response(m, FILES_DIR / "dynamic-form.bpmn")
+        data = {
+            "stringField": "",
+            "intField": "not-an-int",
+            "boolField": "not-a-bool",
+            "dateField": "not-a-timestamp",
+            "enumField": "third",
+        }
 
-    #     with patch("zac.camunda.api.views.complete_task") as mock_complete:
-    #         response = self.client.put(self.endpoint, data)
+        with patch("zac.camunda.api.views.complete_task") as mock_complete:
+            response = self.client.put(self.endpoint, data)
 
-    #     self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-    #     response_data = response.json()
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
 
-    #     # TOD: swap to invalidParams convention
-    #     for key in data:
-    #         with self.subTest(key=key):
-    #             self.assertIn(key, response_data)
+        # TOD: swap to invalidParams convention
+        for key in data:
+            with self.subTest(key=key):
+                self.assertIn(key, response_data)
 
-    #     mock_complete.assert_not_called()
+        mock_complete.assert_not_called()


### PR DESCRIPTION
* Implemented dynamic serializer by fetching the serializer fields from the task definition and calling that in the `__new__` method of the base serializer
* Fixed the schema generation to accommodate for arbitrary hash-maps (using `additionalProperties`), which is the case with this dynamic serializer.

I've considered creating a special base class for these HashMap-serializers, however the `drf_spectacular.openapi.resolve_serializer` will break on that because there are no `properties` in the schema, and it would be discarded (see issue https://github.com/tfranzel/drf-spectacular/issues/299).