### PR TITLE
Makes kownslFrontendUrl absolute so emails include the absolute url

### DIFF
--- a/backend/src/zac/contrib/kownsl/camunda.py
+++ b/backend/src/zac/contrib/kownsl/camunda.py
@@ -15,7 +15,7 @@ from zac.camunda.data import Task
 from zac.camunda.user_tasks import Context, register, usertask_context_serializer
 from zac.core.api.fields import SelectDocumentsField
 from zac.core.camunda.select_documents.serializers import DocumentSerializer
-from zac.core.utils import get_ui_url
+from zac.core.utils import build_absolute_url, get_ui_url
 
 from .api import create_review_request
 from .constants import FORM_KEY_REVIEW_TYPE_MAPPING, KownslTypes
@@ -243,7 +243,7 @@ class ConfigureReviewRequestSerializer(APIModelSerializer):
             "kownslDocuments": self.validated_data["selected_documents"],
             "kownslUsersList": kownsl_users_list,
             "kownslReviewRequestId": str(self.review_request.id),
-            "kownslFrontendUrl": kownsl_frontend_url,
+            "kownslFrontendUrl": build_absolute_url(kownsl_frontend_url),
         }
 
 

--- a/backend/src/zac/contrib/kownsl/tests/test_camunda.py
+++ b/backend/src/zac/contrib/kownsl/tests/test_camunda.py
@@ -22,7 +22,7 @@ from zac.camunda.user_tasks import UserTaskData, get_context as _get_context
 from zac.contrib.dowc.constants import DocFileTypes
 from zac.contrib.dowc.utils import get_dowc_url
 from zac.contrib.kownsl.data import KownslTypes, ReviewRequest
-from zac.core.utils import get_ui_url
+from zac.core.utils import build_absolute_url, get_ui_url
 from zgw.models.zrc import Zaak
 
 from ..camunda import (
@@ -523,15 +523,7 @@ class ConfigureReviewRequestSerializersTests(APITestCase):
                 "kownslDocuments": serializer.validated_data["selected_documents"],
                 "kownslUsersList": [[user.username for user in self.users_1]],
                 "kownslReviewRequestId": str(self.review_request.id),
-                "kownslFrontendUrl": get_ui_url(
-                    [
-                        "ui",
-                        "kownsl",
-                        "review-request",
-                        self.review_request.review_type,
-                    ],
-                    params={"uuid": self.review_request.id},
-                ),
+                "kownslFrontendUrl": f"http://example.com/ui/kownsl/review-request/advice?uuid={self.review_request.id}",
             },
         )
 

--- a/backend/src/zac/contrib/kownsl/tests/test_camunda.py
+++ b/backend/src/zac/contrib/kownsl/tests/test_camunda.py
@@ -22,7 +22,6 @@ from zac.camunda.user_tasks import UserTaskData, get_context as _get_context
 from zac.contrib.dowc.constants import DocFileTypes
 from zac.contrib.dowc.utils import get_dowc_url
 from zac.contrib.kownsl.data import KownslTypes, ReviewRequest
-from zac.core.utils import build_absolute_url, get_ui_url
 from zgw.models.zrc import Zaak
 
 from ..camunda import (


### PR DESCRIPTION
Fixes email part of: https://github.com/GemeenteUtrecht/ZGW/issues/701