### PR TITLE
:bug: #827 - Implement default error message in frontend for keten pr…

### DIFF
--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/keten-processen/keten-processen.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/keten-processen/keten-processen.component.ts
@@ -131,7 +131,7 @@ export class KetenProcessenComponent implements OnChanges, AfterViewInit {
     this.ketenProcessenService.sendMessage(formData).subscribe( () => {
       this.fetchProcesses();
     }, errorRes => {
-      this.sendMessageErrorMessage = errorRes.error.detail;
+      this.sendMessageErrorMessage = errorRes.error.detail || 'Er is een fout opgetreden.';
       this.sendMessageHasError = true;
       this.isLoading = false;
     })


### PR DESCRIPTION
…ocessen.

We might need to improve the backend handling for this as well, as currently. No sensible error message is returned by the backend (yet given by camunda).

@sergei-maertens 