### PR TITLE
Feature/auth profile api

### DIFF
--- a/backend/src/zac/accounts/api/serializers.py
+++ b/backend/src/zac/accounts/api/serializers.py
@@ -413,12 +413,15 @@ class GroupBlueprintSerializer(GroupPolymorphicSerializer):
     object_type = serializers.ChoiceField(choices=PermissionObjectTypeChoices.choices)
 
 
-class AuthProfileSerializer(serializers.ModelSerializer):
-    group_permissions = GroupBlueprintSerializer(many=True)
+class AuthProfileSerializer(serializers.HyperlinkedModelSerializer):
+    blueprint_permissions = GroupBlueprintSerializer(
+        many=True, source="group_permissions"
+    )
 
     class Meta:
         model = AuthorizationProfile
-        fields = ("name", "group_permissions")
+        fields = ("url", "uuid", "name", "blueprint_permissions")
+        extra_kwargs = {"url": {"lookup_field": "uuid"}, "uuid": {"read_only": True}}
 
     @transaction.atomic
     def create(self, validated_data):

--- a/backend/src/zac/accounts/api/serializers.py
+++ b/backend/src/zac/accounts/api/serializers.py
@@ -407,15 +407,22 @@ class GroupBlueprintSerializer(GroupPolymorphicSerializer):
     }
     discriminator_field = "object_type"
     group_field = "policies"
-    group_field_kwargs = {"many": True}
+    group_field_kwargs = {"many": True, "help_text": _("List of blueprint shapes")}
 
-    role = serializers.SlugRelatedField(slug_field="name", queryset=Role.objects.all())
-    object_type = serializers.ChoiceField(choices=PermissionObjectTypeChoices.choices)
+    role = serializers.SlugRelatedField(
+        slug_field="name", queryset=Role.objects.all(), help_text=_("Name of the role")
+    )
+    object_type = serializers.ChoiceField(
+        choices=PermissionObjectTypeChoices.choices,
+        help_text=_("Type of the permission object"),
+    )
 
 
 class AuthProfileSerializer(serializers.HyperlinkedModelSerializer):
     blueprint_permissions = GroupBlueprintSerializer(
-        many=True, source="group_permissions"
+        many=True,
+        source="group_permissions",
+        help_text=_("List of blueprint permissions"),
     )
 
     class Meta:

--- a/backend/src/zac/accounts/api/serializers.py
+++ b/backend/src/zac/accounts/api/serializers.py
@@ -409,8 +409,8 @@ class GroupBlueprintSerializer(GroupPolymorphicSerializer):
     group_field = "policies"
     group_field_kwargs = {"many": True, "help_text": _("List of blueprint shapes")}
 
-    role = serializers.SlugRelatedField(
-        slug_field="name", queryset=Role.objects.all(), help_text=_("Name of the role")
+    role = serializers.PrimaryKeyRelatedField(
+        queryset=Role.objects.all(), help_text=_("Name of the role")
     )
     object_type = serializers.ChoiceField(
         choices=PermissionObjectTypeChoices.choices,

--- a/backend/src/zac/accounts/api/tests/test_authprofile.py
+++ b/backend/src/zac/accounts/api/tests/test_authprofile.py
@@ -1,0 +1,430 @@
+from django.urls import reverse, reverse_lazy
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
+
+from ...constants import PermissionObjectTypeChoices
+from ...models import AuthorizationProfile, BlueprintPermission
+from ...tests.factories import (
+    AuthorizationProfileFactory,
+    BlueprintPermissionFactory,
+    RoleFactory,
+    SuperUserFactory,
+)
+
+CATALOGI_ROOT = "https://api.catalogi.nl/api/v1/"
+CATALOGUS_URL = f"{CATALOGI_ROOT}catalogi/dfb14eb7-9731-4d22-95c2-dff4f33ef36d"
+
+
+class AuthProfileAPITests(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user = SuperUserFactory.create()
+        self.client.force_authenticate(self.user)
+
+    def test_list_auth_profiles(self):
+        role1, role2 = RoleFactory.create_batch(2)
+        blueprint_permission1 = BlueprintPermissionFactory.create(
+            role=role1,
+            object_type=PermissionObjectTypeChoices.zaak,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        blueprint_permission2 = BlueprintPermissionFactory.create(
+            role=role1,
+            object_type=PermissionObjectTypeChoices.zaak,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT2",
+                "max_va": VertrouwelijkheidsAanduidingen.openbaar,
+            },
+        )
+        blueprint_permission3 = BlueprintPermissionFactory.create(
+            role=role2,
+            object_type=PermissionObjectTypeChoices.document,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "iotype_omschrijving": "DT1",
+                "max_va": VertrouwelijkheidsAanduidingen.openbaar,
+            },
+        )
+        auth_profile1, auth_profile2 = AuthorizationProfileFactory.create_batch(2)
+        auth_profile1.blueprint_permissions.add(
+            blueprint_permission1, blueprint_permission2
+        )
+        auth_profile2.blueprint_permissions.add(blueprint_permission3)
+        url = reverse_lazy("authorizationprofile-list")
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            [
+                {
+                    "url": f"http://testserver{reverse('authorizationprofile-detail', args=[auth_profile1.uuid])}",
+                    "uuid": str(auth_profile1.uuid),
+                    "name": auth_profile1.name,
+                    "blueprintPermissions": [
+                        {
+                            "role": role1.name,
+                            "objectType": PermissionObjectTypeChoices.zaak,
+                            "policies": [
+                                {
+                                    "catalogus": CATALOGUS_URL,
+                                    "zaaktypeOmschrijving": "ZT1",
+                                    "maxVa": "zeer_geheim",
+                                },
+                                {
+                                    "catalogus": CATALOGUS_URL,
+                                    "zaaktypeOmschrijving": "ZT2",
+                                    "maxVa": "openbaar",
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "url": f"http://testserver{reverse('authorizationprofile-detail', args=[auth_profile2.uuid])}",
+                    "uuid": str(auth_profile2.uuid),
+                    "name": auth_profile2.name,
+                    "blueprintPermissions": [
+                        {
+                            "role": role2.name,
+                            "objectType": PermissionObjectTypeChoices.document,
+                            "policies": [
+                                {
+                                    "catalogus": CATALOGUS_URL,
+                                    "iotypeOmschrijving": "DT1",
+                                    "maxVa": "openbaar",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        )
+
+    def test_retrieve_auth_profile(self):
+        role1, role2 = RoleFactory.create_batch(2)
+        blueprint_permission1 = BlueprintPermissionFactory.create(
+            role=role1,
+            object_type=PermissionObjectTypeChoices.zaak,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        blueprint_permission2 = BlueprintPermissionFactory.create(
+            role=role1,
+            object_type=PermissionObjectTypeChoices.zaak,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT2",
+                "max_va": VertrouwelijkheidsAanduidingen.openbaar,
+            },
+        )
+        blueprint_permission3 = BlueprintPermissionFactory.create(
+            role=role2,
+            object_type=PermissionObjectTypeChoices.document,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "iotype_omschrijving": "DT1",
+                "max_va": VertrouwelijkheidsAanduidingen.openbaar,
+            },
+        )
+        auth_profile = AuthorizationProfileFactory.create()
+        auth_profile.blueprint_permissions.add(
+            blueprint_permission1, blueprint_permission2, blueprint_permission3
+        )
+        url = reverse("authorizationprofile-detail", args=[auth_profile.uuid])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "url": f"http://testserver{url}",
+                "uuid": str(auth_profile.uuid),
+                "name": auth_profile.name,
+                "blueprintPermissions": [
+                    {
+                        "role": role1.name,
+                        "objectType": PermissionObjectTypeChoices.zaak,
+                        "policies": [
+                            {
+                                "catalogus": CATALOGUS_URL,
+                                "zaaktypeOmschrijving": "ZT1",
+                                "maxVa": "zeer_geheim",
+                            },
+                            {
+                                "catalogus": CATALOGUS_URL,
+                                "zaaktypeOmschrijving": "ZT2",
+                                "maxVa": "openbaar",
+                            },
+                        ],
+                    },
+                    {
+                        "role": role2.name,
+                        "objectType": PermissionObjectTypeChoices.document,
+                        "policies": [
+                            {
+                                "catalogus": CATALOGUS_URL,
+                                "iotypeOmschrijving": "DT1",
+                                "maxVa": "openbaar",
+                            }
+                        ],
+                    },
+                ],
+            },
+        )
+
+    def test_create_auth_profile(self):
+        role1, role2 = RoleFactory.create_batch(2)
+        url = reverse_lazy("authorizationprofile-list")
+        data = {
+            "name": "some name",
+            "blueprintPermissions": [
+                {
+                    "role": role1.name,
+                    "objectType": PermissionObjectTypeChoices.zaak,
+                    "policies": [
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "zaaktypeOmschrijving": "ZT1",
+                            "maxVa": "zeer_geheim",
+                        },
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "zaaktypeOmschrijving": "ZT2",
+                            "maxVa": "openbaar",
+                        },
+                    ],
+                },
+                {
+                    "role": role2.name,
+                    "objectType": PermissionObjectTypeChoices.document,
+                    "policies": [
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "iotypeOmschrijving": "DT1",
+                            "maxVa": "openbaar",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(AuthorizationProfile.objects.count(), 1)
+
+        auth_profile = AuthorizationProfile.objects.get()
+
+        self.assertEqual(auth_profile.name, "some name")
+        self.assertEqual(auth_profile.blueprint_permissions.count(), 3)
+
+        permission1, permission2, permission3 = list(
+            auth_profile.blueprint_permissions.all()
+        )
+        self.assertEqual(permission1.role, role1)
+        self.assertEqual(permission1.object_type, PermissionObjectTypeChoices.zaak)
+        self.assertEqual(
+            permission1.policy,
+            {
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": "zeer_geheim",
+            },
+        )
+        self.assertEqual(permission2.role, role1)
+        self.assertEqual(permission2.object_type, PermissionObjectTypeChoices.zaak)
+        self.assertEqual(
+            permission2.policy,
+            {
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT2",
+                "max_va": "openbaar",
+            },
+        )
+        self.assertEqual(permission3.role, role2)
+        self.assertEqual(permission3.object_type, PermissionObjectTypeChoices.document)
+        self.assertEqual(
+            permission3.policy,
+            {
+                "catalogus": CATALOGUS_URL,
+                "iotype_omschrijving": "DT1",
+                "max_va": "openbaar",
+            },
+        )
+
+    def test_create_auth_profile_reuse_existing_permissions(self):
+        role1, role2 = RoleFactory.create_batch(2)
+        blueprint_permission1 = BlueprintPermissionFactory.create(
+            role=role1,
+            object_type=PermissionObjectTypeChoices.zaak,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        blueprint_permission2 = BlueprintPermissionFactory.create(
+            role=role1,
+            object_type=PermissionObjectTypeChoices.zaak,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT2",
+                "max_va": VertrouwelijkheidsAanduidingen.openbaar,
+            },
+        )
+        blueprint_permission3 = BlueprintPermissionFactory.create(
+            role=role2,
+            object_type=PermissionObjectTypeChoices.document,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "iotype_omschrijving": "DT1",
+                "max_va": VertrouwelijkheidsAanduidingen.openbaar,
+            },
+        )
+        url = reverse_lazy("authorizationprofile-list")
+        data = {
+            "name": "some name",
+            "blueprintPermissions": [
+                {
+                    "role": role1.name,
+                    "objectType": PermissionObjectTypeChoices.zaak,
+                    "policies": [
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "zaaktypeOmschrijving": "ZT1",
+                            "maxVa": "zeer_geheim",
+                        },
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "zaaktypeOmschrijving": "ZT2",
+                            "maxVa": "openbaar",
+                        },
+                    ],
+                },
+                {
+                    "role": role2.name,
+                    "objectType": PermissionObjectTypeChoices.document,
+                    "policies": [
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "iotypeOmschrijving": "DT1",
+                            "maxVa": "openbaar",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(AuthorizationProfile.objects.count(), 1)
+
+        auth_profile = AuthorizationProfile.objects.get()
+
+        self.assertEqual(auth_profile.name, "some name")
+        self.assertEqual(auth_profile.blueprint_permissions.count(), 3)
+        self.assertEqual(BlueprintPermission.objects.count(), 3)
+
+        for permission in [
+            blueprint_permission1,
+            blueprint_permission2,
+            blueprint_permission3,
+        ]:
+            self.assertTrue(
+                auth_profile.blueprint_permissions.filter(id=permission.id).exists()
+            )
+
+    def test_create_auth_profile_policy_incorrect_shape(self):
+        role = RoleFactory.create()
+        url = reverse_lazy("authorizationprofile-list")
+        data = {
+            "name": "some name",
+            "blueprintPermissions": [
+                {
+                    "role": role.name,
+                    "objectType": PermissionObjectTypeChoices.zaak,
+                    "policies": [
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "zaaktypeOmschrijving": "ZT1",
+                        },
+                    ],
+                }
+            ],
+        }
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "blueprintPermissions": [
+                    {"policies": [{"maxVa": ["Dit veld is vereist."]}]}
+                ]
+            },
+        )
+
+    def test_update_auth_profile(self):
+        role = RoleFactory.create()
+        blueprint_permission = BlueprintPermissionFactory.create(
+            role=role,
+            object_type=PermissionObjectTypeChoices.zaak,
+            policy={
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        auth_profile = AuthorizationProfileFactory.create()
+        auth_profile.blueprint_permissions.add(blueprint_permission)
+        url = reverse("authorizationprofile-detail", args=[auth_profile.uuid])
+        data = {
+            "name": auth_profile.name,
+            "blueprintPermissions": [
+                {
+                    "role": role.name,
+                    "objectType": PermissionObjectTypeChoices.zaak,
+                    "policies": [
+                        {
+                            "catalogus": CATALOGUS_URL,
+                            "zaaktypeOmschrijving": "ZT2",
+                            "maxVa": "openbaar",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        response = self.client.put(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        auth_profile.refresh_from_db()
+
+        self.assertEqual(auth_profile.blueprint_permissions.count(), 1)
+
+        permission = auth_profile.blueprint_permissions.get()
+
+        self.assertEqual(
+            permission.policy,
+            {
+                "catalogus": CATALOGUS_URL,
+                "zaaktype_omschrijving": "ZT2",
+                "max_va": "openbaar",
+            },
+        )

--- a/backend/src/zac/accounts/api/tests/test_authprofile.py
+++ b/backend/src/zac/accounts/api/tests/test_authprofile.py
@@ -102,7 +102,7 @@ class AuthProfileAPITests(APITestCase):
                     "name": auth_profile1.name,
                     "blueprintPermissions": [
                         {
-                            "role": role1.name,
+                            "role": role1.id,
                             "objectType": PermissionObjectTypeChoices.zaak,
                             "policies": [
                                 {
@@ -125,7 +125,7 @@ class AuthProfileAPITests(APITestCase):
                     "name": auth_profile2.name,
                     "blueprintPermissions": [
                         {
-                            "role": role2.name,
+                            "role": role2.id,
                             "objectType": PermissionObjectTypeChoices.document,
                             "policies": [
                                 {
@@ -186,7 +186,7 @@ class AuthProfileAPITests(APITestCase):
                 "name": auth_profile.name,
                 "blueprintPermissions": [
                     {
-                        "role": role1.name,
+                        "role": role1.id,
                         "objectType": PermissionObjectTypeChoices.zaak,
                         "policies": [
                             {
@@ -202,7 +202,7 @@ class AuthProfileAPITests(APITestCase):
                         ],
                     },
                     {
-                        "role": role2.name,
+                        "role": role2.id,
                         "objectType": PermissionObjectTypeChoices.document,
                         "policies": [
                             {
@@ -223,7 +223,7 @@ class AuthProfileAPITests(APITestCase):
             "name": "some name",
             "blueprintPermissions": [
                 {
-                    "role": role1.name,
+                    "role": role1.id,
                     "objectType": PermissionObjectTypeChoices.zaak,
                     "policies": [
                         {
@@ -239,7 +239,7 @@ class AuthProfileAPITests(APITestCase):
                     ],
                 },
                 {
-                    "role": role2.name,
+                    "role": role2.id,
                     "objectType": PermissionObjectTypeChoices.document,
                     "policies": [
                         {
@@ -330,7 +330,7 @@ class AuthProfileAPITests(APITestCase):
             "name": "some name",
             "blueprintPermissions": [
                 {
-                    "role": role1.name,
+                    "role": role1.id,
                     "objectType": PermissionObjectTypeChoices.zaak,
                     "policies": [
                         {
@@ -346,7 +346,7 @@ class AuthProfileAPITests(APITestCase):
                     ],
                 },
                 {
-                    "role": role2.name,
+                    "role": role2.id,
                     "objectType": PermissionObjectTypeChoices.document,
                     "policies": [
                         {
@@ -386,7 +386,7 @@ class AuthProfileAPITests(APITestCase):
             "name": "some name",
             "blueprintPermissions": [
                 {
-                    "role": role.name,
+                    "role": role.id,
                     "objectType": PermissionObjectTypeChoices.zaak,
                     "policies": [
                         {
@@ -427,7 +427,7 @@ class AuthProfileAPITests(APITestCase):
             "name": auth_profile.name,
             "blueprintPermissions": [
                 {
-                    "role": role.name,
+                    "role": role.id,
                     "objectType": PermissionObjectTypeChoices.zaak,
                     "policies": [
                         {

--- a/backend/src/zac/accounts/api/urls.py
+++ b/backend/src/zac/accounts/api/urls.py
@@ -6,6 +6,7 @@ from .views import InformatieobjecttypenJSONView
 from .viewsets import (
     AccessRequestViewSet,
     AtomicPermissionViewSet,
+    AuthProfileViewSet,
     GroupViewSet,
     UserViewSet,
 )
@@ -15,6 +16,7 @@ router.register("groups", GroupViewSet, basename="groups")
 router.register("users", UserViewSet, basename="users")
 router.register("access-requests", AccessRequestViewSet)
 router.register("cases/access", AtomicPermissionViewSet, basename="accesses")
+router.register("auth-profiles", AuthProfileViewSet, basename="authprofiles")
 
 urlpatterns = router.urls + [
     path(

--- a/backend/src/zac/accounts/api/urls.py
+++ b/backend/src/zac/accounts/api/urls.py
@@ -16,7 +16,7 @@ router.register("groups", GroupViewSet, basename="groups")
 router.register("users", UserViewSet, basename="users")
 router.register("access-requests", AccessRequestViewSet)
 router.register("cases/access", AtomicPermissionViewSet, basename="accesses")
-router.register("auth-profiles", AuthProfileViewSet, basename="authprofiles")
+router.register("auth-profiles", AuthProfileViewSet)
 
 urlpatterns = router.urls + [
     path(

--- a/backend/src/zac/accounts/api/viewsets.py
+++ b/backend/src/zac/accounts/api/viewsets.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Group
 from django.db import transaction
+from django.db.models import Count, Prefetch
 from django.utils.translation import gettext_lazy as _
 
 from django_filters import rest_framework as django_filter
@@ -14,12 +15,19 @@ from zac.utils.mixins import PatchModelMixin
 
 from ..constants import AccessRequestResult
 from ..email import send_email_to_requester
-from ..models import AccessRequest, User, UserAtomicPermission
+from ..models import (
+    AccessRequest,
+    AuthorizationProfile,
+    BlueprintPermission,
+    User,
+    UserAtomicPermission,
+)
 from .filters import UserFilter
 from .permissions import CanCreateOrHandleAccessRequest, CanGrantAccess
 from .serializers import (
     AccessRequestDetailSerializer,
     AtomicPermissionSerializer,
+    AuthProfileSerializer,
     CreateAccessRequestSerializer,
     GrantPermissionSerializer,
     GroupSerializer,
@@ -151,3 +159,12 @@ class AtomicPermissionViewSet(
                 ui=True,
             )
         )
+
+
+class AuthProfileViewSet(
+    mixins.CreateModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
+):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+    queryset = AuthorizationProfile.objects.all()
+    serializer_class = AuthProfileSerializer

--- a/backend/src/zac/accounts/api/viewsets.py
+++ b/backend/src/zac/accounts/api/viewsets.py
@@ -162,7 +162,9 @@ class AtomicPermissionViewSet(
 
 
 class AuthProfileViewSet(
-    mixins.CreateModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    viewsets.ReadOnlyModelViewSet,
 ):
     authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]

--- a/backend/src/zac/accounts/api/viewsets.py
+++ b/backend/src/zac/accounts/api/viewsets.py
@@ -170,3 +170,4 @@ class AuthProfileViewSet(
     permission_classes = [IsAuthenticated]
     queryset = AuthorizationProfile.objects.all()
     serializer_class = AuthProfileSerializer
+    lookup_field = "uuid"

--- a/backend/src/zac/accounts/api/viewsets.py
+++ b/backend/src/zac/accounts/api/viewsets.py
@@ -161,6 +161,12 @@ class AtomicPermissionViewSet(
         )
 
 
+@extend_schema_view(
+    list=extend_schema(summary=_("List authorization profiles")),
+    retrieve=extend_schema(summary=_("Retrieve authorization profile")),
+    create=extend_schema(summary=_("Create authorization profile")),
+    update=extend_schema(summary=_("Update authorization profile")),
+)
 class AuthProfileViewSet(
     mixins.CreateModelMixin,
     mixins.UpdateModelMixin,

--- a/backend/src/zac/accounts/api/viewsets.py
+++ b/backend/src/zac/accounts/api/viewsets.py
@@ -10,7 +10,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 
 from zac.core.api.pagination import BffPagination
-from zac.utils.mixins import PatchModelMixin
+from zac.utils.mixins import PatchModelMixin, UpdateModelMixin
 
 from ..constants import AccessRequestResult
 from ..email import send_email_to_requester
@@ -162,7 +162,7 @@ class AtomicPermissionViewSet(
 )
 class AuthProfileViewSet(
     mixins.CreateModelMixin,
-    mixins.UpdateModelMixin,
+    UpdateModelMixin,
     viewsets.ReadOnlyModelViewSet,
 ):
     authentication_classes = [SessionAuthentication]

--- a/backend/src/zac/accounts/api/viewsets.py
+++ b/backend/src/zac/accounts/api/viewsets.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import Group
 from django.db import transaction
-from django.db.models import Count, Prefetch
 from django.utils.translation import gettext_lazy as _
 
 from django_filters import rest_framework as django_filter
@@ -8,20 +7,14 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, mixins, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
 
 from zac.core.api.pagination import BffPagination
 from zac.utils.mixins import PatchModelMixin
 
 from ..constants import AccessRequestResult
 from ..email import send_email_to_requester
-from ..models import (
-    AccessRequest,
-    AuthorizationProfile,
-    BlueprintPermission,
-    User,
-    UserAtomicPermission,
-)
+from ..models import AccessRequest, AuthorizationProfile, User, UserAtomicPermission
 from .filters import UserFilter
 from .permissions import CanCreateOrHandleAccessRequest, CanGrantAccess
 from .serializers import (
@@ -173,7 +166,7 @@ class AuthProfileViewSet(
     viewsets.ReadOnlyModelViewSet,
 ):
     authentication_classes = [SessionAuthentication]
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsAdminUser]
     queryset = AuthorizationProfile.objects.all()
     serializer_class = AuthProfileSerializer
     lookup_field = "uuid"

--- a/backend/src/zac/api/drf_spectacular/polymorphic.py
+++ b/backend/src/zac/api/drf_spectacular/polymorphic.py
@@ -31,10 +31,9 @@ class PolymorphicSerializerExtension(OpenApiSerializerExtension):
         auto_schema.registry.register(main)
 
         # build the components for the polymorphic extra fields
-        for (
-            discriminator_value,
-            sub_serializer,
-        ) in serializer.serializer_mapping.items():
+        for discriminator_value in list(serializer.serializer_mapping.keys()):
+
+            sub_serializer = serializer._discriminator_serializer(discriminator_value)
             resolved = auto_schema.resolve_serializer(sub_serializer, direction)
 
             if not resolved.name:

--- a/backend/src/zac/api/drf_spectacular/polymorphic.py
+++ b/backend/src/zac/api/drf_spectacular/polymorphic.py
@@ -31,7 +31,7 @@ class PolymorphicSerializerExtension(OpenApiSerializerExtension):
         auto_schema.registry.register(main)
 
         # build the components for the polymorphic extra fields
-        for discriminator_value in list(serializer.serializer_mapping.keys()):
+        for discriminator_value in serializer.serializer_mapping.keys():
 
             sub_serializer = serializer._discriminator_serializer(discriminator_value)
             resolved = auto_schema.resolve_serializer(sub_serializer, direction)

--- a/backend/src/zac/api/polymorphism.py
+++ b/backend/src/zac/api/polymorphism.py
@@ -144,3 +144,24 @@ class PolymorphicSerializer(serializers.Serializer):
         )
         serializer = self._discriminator_serializer(discriminator_value)
         return serializer
+
+
+class GroupPolymorphicSerializer(PolymorphicSerializer):
+    """
+    polymorhic fields are grouped into one particular field
+    """
+
+    group_field = None
+    group_field_kwargs = {}
+
+    def _discriminator_serializer(self, discriminator_value: str):
+        serializer = super()._discriminator_serializer(discriminator_value)
+
+        group_name = f"{self.group_field}_{serializer.__class__.__name__}"
+        group_field = serializer.__class__(**self.group_field_kwargs)
+        group_serializer_class = type(
+            group_name,
+            (serializers.Serializer,),
+            {self.group_field: group_field},
+        )
+        return group_serializer_class()

--- a/backend/src/zac/api/polymorphism.py
+++ b/backend/src/zac/api/polymorphism.py
@@ -157,7 +157,7 @@ class GroupPolymorphicSerializer(PolymorphicSerializer):
     def _discriminator_serializer(self, discriminator_value: str):
         serializer = super()._discriminator_serializer(discriminator_value)
 
-        group_name = f"{self.group_field}_{serializer.__class__.__name__}"
+        group_name = f"{self.group_field.capitalize()}{serializer.__class__.__name__}"
         group_field = serializer.__class__(**self.group_field_kwargs)
         group_serializer_class = type(
             group_name,

--- a/backend/src/zac/conf/includes/base.py
+++ b/backend/src/zac/conf/includes/base.py
@@ -134,10 +134,10 @@ INSTALLED_APPS = [
     "hijack_admin",
     "django_better_admin_arrayfield",
     # Project applications.
+    "zac.elasticsearch",
     "zac.accounts",
     "zac.camunda",
     "zac.core",
-    "zac.elasticsearch",
     "zac.notifications",
     "zac.forms",
     "zac.utils",

--- a/backend/src/zac/utils/mixins.py
+++ b/backend/src/zac/utils/mixins.py
@@ -22,3 +22,26 @@ class PatchModelMixin:
 
     def perform_update(self, serializer):
         serializer.save()
+
+
+class UpdateModelMixin:
+    """
+    Allows only PUT without PATCH
+    """
+
+    def update(self, request, *args, **kwargs):
+        partial = False
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+
+        if getattr(instance, "_prefetched_objects_cache", None):
+            # If 'prefetch_related' has been applied to a queryset, we need to
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}
+
+        return Response(serializer.data)
+
+    def perform_update(self, serializer):
+        serializer.save()


### PR DESCRIPTION
issue - https://github.com/GemeenteUtrecht/ZGW/issues/773 
auth profile endpoints shape - https://gist.github.com/annashamray/e53f44de0f0a1b8154898084c62b5ba7

**Done in the PR:**
* add GET, POST and PUT endpoints for `AuthorizationProfile`

**To do in the next PRs:**
* ~~add role endpoints~~ - done in #407 
* ~~add endpoints to relate users and auth profiles~~ -  in #409 - closed

**Note:**
Auth profile endpoins are restricted for staff users. 
Another option was to check for the existing `"zaken:toegang-verlenen"` but there is no specific zaak to check this permission against. 