### PR TITLE
Increase index_zaken code coherence and performance

### DIFF
--- a/backend/src/zac/contrib/board/tests/test_boarditem_api.py
+++ b/backend/src/zac/contrib/board/tests/test_boarditem_api.py
@@ -1,5 +1,4 @@
 import uuid
-from unittest.mock import patch
 
 from django.urls import reverse
 
@@ -66,14 +65,10 @@ class BoardItemPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
         zaak_model = factory(Zaak, self.zaak)
         zaak_model.zaaktype = zaaktype_model
 
-        patch_get_zaakobjecten = patch(
-            "zac.elasticsearch.api.get_zaakobjecten",
-            return_value=[],
-        )
-        patch_get_zaakobjecten.start()
-        self.addCleanup(patch_get_zaakobjecten.stop)
+        zaak_document = self.create_zaak_document(zaak_model)
+        zaak_document.zaaktype = self.create_zaaktype_document(zaaktype_model)
+        zaak_document.save()
 
-        self.create_zaak_document(zaak_model)
         self.refresh_index()
 
     def _setUpMock(self, m):
@@ -306,14 +301,9 @@ class BoardItemAPITests(ESMixin, APITestCase):
         zaak_model = factory(Zaak, self.zaak)
         zaak_model.zaaktype = zaaktype_model
 
-        patch_get_zaakobjecten = patch(
-            "zac.elasticsearch.api.get_zaakobjecten",
-            return_value=[],
-        )
-        patch_get_zaakobjecten.start()
-        self.addCleanup(patch_get_zaakobjecten.stop)
-
-        self.create_zaak_document(zaak_model)
+        zaak_document = self.create_zaak_document(zaak_model)
+        zaak_document.zaaktype = self.create_zaaktype_document(zaaktype_model)
+        zaak_document.save()
         self.refresh_index()
 
         self.zaak_data = {

--- a/backend/src/zac/core/api/tests/test_zaak_detail.py
+++ b/backend/src/zac/core/api/tests/test_zaak_detail.py
@@ -125,7 +125,9 @@ class ZaakDetailResponseTests(ESMixin, ClearCachesMixin, APITestCase):
         mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
         mock_resource_get(m, self.zaak)
         mock_resource_get(m, self.zaaktype)
-        self.create_zaak_document(self.zaak)
+        zaak_document = self.create_zaak_document(self.zaak)
+        zaak_document.zaaktype = self.create_zaaktype_document(self.zaaktype)
+        zaak_document.save()
         self.refresh_index()
 
         response = self.client.get(self.detail_url)

--- a/backend/src/zac/core/services.py
+++ b/backend/src/zac/core/services.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urljoin
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
@@ -358,8 +358,6 @@ def get_zaken_all_paginated(
     Used to index Zaken in ES.
     Should not be used for searches with user permissions
     """
-    from urllib.parse import parse_qs, urlparse
-
     response = client.list("zaak", query_params=query_params)
     zaken = factory(Zaak, response["results"])
 

--- a/backend/src/zac/core/services.py
+++ b/backend/src/zac/core/services.py
@@ -24,6 +24,7 @@ from zgw_consumers.api_models.catalogi import (
 from zgw_consumers.api_models.constants import RolTypes
 from zgw_consumers.api_models.documenten import Document
 from zgw_consumers.api_models.zaken import Resultaat, Status, ZaakEigenschap, ZaakObject
+from zgw_consumers.client import ZGWClient
 from zgw_consumers.concurrent import parallel
 from zgw_consumers.constants import APITypes
 from zgw_consumers.models import Service
@@ -346,6 +347,31 @@ def get_zaken_es(
         zaak.zaaktype = zaaktypen[zaak.zaaktype]
 
     return zaken
+
+
+def get_zaken_all_paginated(
+    client: ZGWClient,
+    query_params: dict = {},
+) -> Tuple[List[Zaak], dict]:
+    """
+    Fetch all zaken from the ZRCs in batches.
+    Used to index Zaken in ES.
+    Should not be used for searches with user permissions
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    response = client.list("zaak", query_params=query_params)
+    zaken = factory(Zaak, response["results"])
+
+    if response["next"]:
+        next_url = urlparse(response["next"])
+        query = parse_qs(next_url.query)
+        new_page = int(query["page"][0])
+        query_params["page"] = [new_page]
+    else:
+        query_params["page"] = None
+
+    return zaken, query_params
 
 
 def get_zaken_all(

--- a/backend/src/zac/elasticsearch/api.py
+++ b/backend/src/zac/elasticsearch/api.py
@@ -10,6 +10,7 @@ from zgw_consumers.api_models.zaken import Status, ZaakEigenschap, ZaakObject
 from zac.core.rollen import Rol
 from zac.core.services import (
     get_rollen,
+    get_status,
     get_statustype,
     get_zaak_eigenschappen,
     get_zaakobjecten,
@@ -63,6 +64,8 @@ def _get_zaak_document(
             return
         else:
             zaak_document = create_zaak_document(create_zaak)
+            zaak_document.save()
+
     return zaak_document
 
 
@@ -129,11 +132,12 @@ def create_status_document(status: Status) -> StatusDocument:
 
 
 def update_status_in_zaak_document(zaak: Zaak) -> None:
-    status_document = create_status_document(zaak.status) if zaak.status else None
-
-    zaak_document = _get_zaak_document(zaak.uuid, zaak.url, create_zaak=zaak)
-    zaak_document.status = status_document
-    zaak_document.save()
+    if zaak.status:
+        zaak.status = get_status(zaak) if isinstance(zaak.status, str) else zaak.status
+        status_document = create_status_document(zaak.status)
+        zaak_document = _get_zaak_document(zaak.uuid, zaak.url, create_zaak=zaak)
+        zaak_document.status = status_document
+        zaak_document.save()
 
     return
 

--- a/backend/src/zac/elasticsearch/api.py
+++ b/backend/src/zac/elasticsearch/api.py
@@ -183,23 +183,19 @@ def update_eigenschappen_in_zaak_document(zaak: Zaak) -> None:
     return
 
 
-def create_zaakobjecten_document(
-    zaakobjecten: List[ZaakObject],
-) -> List[ZaakObjectDocument]:
-    return [
-        ZaakObjectDocument(
-            url=zo.url,
-            object=zo.object,
-        )
-        for zo in zaakobjecten
-    ]
+def create_zaakobject_document(
+    zaakobject: ZaakObject,
+) -> ZaakObjectDocument:
+    return ZaakObjectDocument(url=zaakobject.url, object=zaakobject.object)
 
 
 def update_zaakobjecten_in_zaak_document(zaak: Zaak) -> None:
     zaak.zaakobjecten = get_zaakobjecten(zaak)
 
     zaak_document = _get_zaak_document(zaak.uuid, zaak.url, create_zaak=zaak)
-    zaak_document.zaakobjecten = create_zaakobjecten_document(zaak.zaakobjecten)
+    zaak_document.zaakobjecten = [
+        create_zaakobject_document(zo) for zo in zaak.zaakobjecten
+    ]
     zaak_document.save()
 
     return

--- a/backend/src/zac/elasticsearch/drf_api/views.py
+++ b/backend/src/zac/elasticsearch/drf_api/views.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from zac.api.drf_spectacular.utils import input_serializer_to_parameters
+from zac.core.api.permissions import CanReadZaken
 from zac.core.api.serializers import ZaakSerializer
 from zac.core.services import get_zaaktypen
 
@@ -49,7 +50,7 @@ class GetZakenView(views.APIView):
         serializer = ZaakIdentificatieSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         zaken = autocomplete_zaak_search(
-            identificatie=serializer.validated_data["identificatie"]
+            request.user, identificatie=serializer.validated_data["identificatie"]
         )
         zaak_serializer = self.get_serializer(instance=zaken)
         return Response(data=zaak_serializer.data)

--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -1,16 +1,40 @@
+import logging
+from typing import Dict, List
+
 from django.conf import settings
 from django.core.management import BaseCommand
 
+from elasticsearch.helpers import bulk
 from elasticsearch_dsl import Index
+from elasticsearch_dsl.connections import connections
+from zgw_consumers.concurrent import parallel
 
-from zac.core.services import get_rollen_all, get_zaken_all
+from zac.core.services import (
+    fetch_zaaktype,
+    get_rollen_all,
+    get_status,
+    get_zaak_eigenschappen,
+    get_zaakobjecten,
+    get_zaken_all,
+)
+from zgw.models import Zaak
 
 from ...api import (
-    append_rol_to_document,
+    create_eigenschappen_document,
+    create_rol_document,
+    create_status_document,
     create_zaak_document,
-    update_eigenschappen_in_zaak_document,
+    create_zaakobjecten_document,
+    create_zaaktype_document,
 )
-from ...documents import ZaakDocument
+from ...documents import (
+    EigenschapDocument,
+    RolDocument,
+    StatusDocument,
+    ZaakDocument,
+    ZaakObjectDocument,
+    ZaakTypeDocument,
+)
 
 
 class Command(BaseCommand):
@@ -20,40 +44,111 @@ class Command(BaseCommand):
         self.clear_zaken_index()
 
         zaken = get_zaken_all()
-        self.stdout.write(f"{len(zaken)} zaken are received from Zaken API")
+        self.stdout.write(f"{len(zaken)} zaken are received from Zaken API.")
 
-        self.index_zaken(zaken)
-        self.index_rollen()
-        self.index_zaak_eigenschappen(zaken)
+        zaak_documenten = self.create_zaak_documenten(zaken)
+        zaaktype_documenten = self.create_zaaktype_documenten(zaken)
+        status_documenten = self.create_status_documenten(zaken)
+        rollen_documenten = self.create_rollen_documenten()
+        eigenschappen_documenten = self.create_eigenschappen_documenten(zaken)
+        zaakobjecten_documenten = self.create_zaakobjecten_documenten(zaken)
 
-        self.stdout.write("Zaken have been indexed")
+        final = []
+        for zaak in zaken:
+            zaakdocument = zaak_documenten[zaak.url]
+            zaakdocument.zaaktype = zaaktype_documenten[zaak.url]
+            zaakdocument.status = status_documenten.get(zaak.url, None)
+            zaakdocument.rollen = rollen_documenten.get(zaak.url, [])
+            zaakdocument.eigenschappen = eigenschappen_documenten.get(zaak.url, {})
+            zaakdocument.zaakobjecten = zaakobjecten_documenten.get(zaak.url, [])
+            final.append(zaakdocument.to_dict(True))
+
+        bulk(connections.get_connection(), final)
+        self.stdout.write(f"All zaken have been indexed.")
 
     def clear_zaken_index(self):
         zaken = Index(settings.ES_INDEX_ZAKEN)
         zaken.delete(ignore=404)
 
-    def index_zaken(self, zaken):
-        # create/refresh mapping in the ES
+    def create_zaak_documenten(self, zaken: List[Zaak]) -> Dict[str, ZaakDocument]:
         ZaakDocument.init()
 
-        # TODO replace with bulk API
-        for zaak in zaken:
-            create_zaak_document(zaak)
+        # Build the zaak_documenten
+        zaak_documenten = {zaak.url: create_zaak_document(zaak) for zaak in zaken}
+        return zaak_documenten
 
-    def index_rollen(self):
+    def create_zaaktype_documenten(
+        self, zaken: List[Zaak]
+    ) -> Dict[str, ZaakTypeDocument]:
+        unfetched_zaaktypen = [
+            zaak.zaaktype for zaak in zaken if isinstance(zaak.zaaktype, str)
+        ]
+        with parallel(max_workers=10) as executor:
+            results = executor.map(fetch_zaaktype, unfetched_zaaktypen)
+        zaaktypen = {zaaktype.url: zaaktype for zaaktype in list(results)}
+
+        for zaak in zaken:
+            if isinstance(zaak.zaaktype, str):
+                zaak.zaaktype = zaaktypen[zaak.zaaktype]
+
+        zaaktype_documenten = {
+            zaak.url: create_zaaktype_document(zaak.zaaktype) for zaak in zaken
+        }
+        return zaaktype_documenten
+
+    def create_status_documenten(self, zaken: List[Zaak]) -> Dict[str, StatusDocument]:
+        with parallel(max_workers=10) as executor:
+            results = executor.map(get_status, zaken)
+        status_documenten = {
+            status.zaak: create_status_document(status)
+            for status in list(results)
+            if status
+        }
+        self.stdout.write(
+            f"{len(status_documenten.keys())} statussen are received from Zaken API."
+        )
+        return status_documenten
+
+    def create_rollen_documenten(self) -> Dict[str, RolDocument]:
         rollen = get_rollen_all()
-        self.stdout.write(f"{len(rollen)} rollen are received from Zaken API")
+        rollen_documenten = {rol.zaak: [] for rol in rollen}
 
         for rol in rollen:
-            append_rol_to_document(rol)
-
-    def index_zaak_eigenschappen(self, zaken):
-        for zaak in zaken:
-            if zaak.eigenschappen:
-                update_eigenschappen_in_zaak_document(zaak)
-
+            rollen_documenten[rol.zaak].append(create_rol_document(rol))
         self.stdout.write(
-            "eigenschappen were indexed for {} zaken".format(
-                len([zaak for zaak in zaken if zaak.eigenschappen])
-            )
+            f"{len(rollen)} rollen are received for {len(rollen_documenten.keys())} zaken."
         )
+        return rollen_documenten
+
+    def create_eigenschappen_documenten(
+        self, zaken: List[Zaak]
+    ) -> Dict[str, EigenschapDocument]:
+        # Prefetch zaakeigenschappen
+        with parallel(max_workers=10) as executor:
+            results = executor.map(get_zaak_eigenschappen, zaken)
+        list_of_eigenschappen = list(results)
+
+        eigenschappen_documenten = {
+            zen[0].zaak.url: create_eigenschappen_document(zen)
+            for zen in list_of_eigenschappen
+            if zen
+        }
+        self.stdout.write(
+            f"{sum([len(zen) for zen in list_of_eigenschappen])} zaakeigenschappen are found for {len(eigenschappen_documenten.keys())} zaken."
+        )
+        return eigenschappen_documenten
+
+    def create_zaakobjecten_documenten(
+        self, zaken: List[Zaak]
+    ) -> Dict[str, ZaakObjectDocument]:
+        # Prefetch zaakobjecten
+        with parallel(max_workers=10) as executor:
+            results = executor.map(get_zaakobjecten, zaken)
+        list_of_zon = list(results)
+        zaakobjecten_documenten = {
+            zon[0].zaak: create_zaakobjecten_document(zon) for zon in list_of_zon if zon
+        }
+        self.stdout.write(
+            f"{sum([len(zon) for zon in list_of_zon])} zaakobjecten are found for {len(zaakobjecten_documenten.keys())} zaken."
+        )
+        return zaakobjecten_documenten

--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -1,5 +1,3 @@
-import logging
-import time
 from typing import Dict, List
 
 from django.conf import settings
@@ -40,8 +38,6 @@ from ...documents import (
     ZaakTypeDocument,
 )
 
-logging.disable(logging.CRITICAL)
-
 
 class Command(BaseCommand):
     help = "Create documents in ES by indexing all zaken from ZAKEN API"
@@ -52,7 +48,6 @@ class Command(BaseCommand):
 
         zrcs = Service.objects.filter(api_type=APITypes.zrc)
         clients = [zrc.build_client() for zrc in zrcs]
-        then = time.time()
         for client in clients:
             get_more = True
             query_params = {}
@@ -65,8 +60,6 @@ class Command(BaseCommand):
                     zaak.zaaktype = zaaktypen[zaak.zaaktype]
 
                 yield from self.zaakdocumenten_generator(zaken)
-        now = time.time()
-        print(f"IT TOOK {now-then}s.")
 
     def zaakdocumenten_generator(self, zaken: List[Zaak]) -> List[ZaakDocument]:
         zaak_documenten = self.create_zaak_documenten(zaken)

--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -24,7 +24,7 @@ from ...api import (
     create_rol_document,
     create_status_document,
     create_zaak_document,
-    create_zaakobjecten_document,
+    create_zaakobject_document,
     create_zaaktype_document,
 )
 from ...documents import (
@@ -138,7 +138,7 @@ class Command(BaseCommand):
         )
         return eigenschappen_documenten
 
-    def create_zaakobjecten_documenten(
+    def create_zaakobject_documenten(
         self, zaken: List[Zaak]
     ) -> Dict[str, ZaakObjectDocument]:
         # Prefetch zaakobjecten
@@ -146,7 +146,9 @@ class Command(BaseCommand):
             results = executor.map(get_zaakobjecten, zaken)
         list_of_zon = list(results)
         zaakobjecten_documenten = {
-            zon[0].zaak: create_zaakobjecten_document(zon) for zon in list_of_zon if zon
+            zon[0].zaak: [create_zaakobject_document(zo) for zo in zon]
+            for zon in list_of_zon
+            if zon
         }
         self.stdout.write(
             f"{sum([len(zon) for zon in list_of_zon])} zaakobjecten are found for {len(zaakobjecten_documenten.keys())} zaken."

--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -80,9 +80,9 @@ class Command(BaseCommand):
     def create_zaaktype_documenten(
         self, zaken: List[Zaak]
     ) -> Dict[str, ZaakTypeDocument]:
-        unfetched_zaaktypen = [
+        unfetched_zaaktypen = {
             zaak.zaaktype for zaak in zaken if isinstance(zaak.zaaktype, str)
-        ]
+        }
         with parallel(max_workers=10) as executor:
             results = executor.map(fetch_zaaktype, unfetched_zaaktypen)
         zaaktypen = {zaaktype.url: zaaktype for zaaktype in list(results)}

--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
         status_documenten = self.create_status_documenten(zaken)
         rollen_documenten = self.create_rollen_documenten()
         eigenschappen_documenten = self.create_eigenschappen_documenten(zaken)
-        zaakobjecten_documenten = self.create_zaakobjecten_documenten(zaken)
+        zaakobjecten_documenten = self.create_zaakobject_documenten(zaken)
 
         final = []
         for zaak in zaken:
@@ -125,8 +125,7 @@ class Command(BaseCommand):
     ) -> Dict[str, EigenschapDocument]:
         # Prefetch zaakeigenschappen
         with parallel(max_workers=10) as executor:
-            results = executor.map(get_zaak_eigenschappen, zaken)
-        list_of_eigenschappen = list(results)
+            list_of_eigenschappen = list(executor.map(get_zaak_eigenschappen, zaken))
 
         eigenschappen_documenten = {
             zen[0].zaak.url: create_eigenschappen_document(zen)
@@ -143,8 +142,8 @@ class Command(BaseCommand):
     ) -> Dict[str, ZaakObjectDocument]:
         # Prefetch zaakobjecten
         with parallel(max_workers=10) as executor:
-            results = executor.map(get_zaakobjecten, zaken)
-        list_of_zon = list(results)
+            list_of_zon = list(executor.map(get_zaakobjecten, zaken))
+
         zaakobjecten_documenten = {
             zon[0].zaak: [create_zaakobject_document(zo) for zo in zon]
             for zon in list_of_zon

--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -137,7 +137,7 @@ class Command(BaseCommand):
         list_of_rollen = [rollen for rollen in results if rollen]
 
         rollen_documenten = {
-            rollen[0].zaak.url: [create_rol_document(rol) for rol in rollen]
+            rollen[0].zaak: [create_rol_document(rol) for rol in rollen]
             for rollen in list_of_rollen
         }
         self.stdout.write(
@@ -153,7 +153,7 @@ class Command(BaseCommand):
             list_of_eigenschappen = list(executor.map(get_zaak_eigenschappen, zaken))
 
         eigenschappen_documenten = {
-            zen[0].zaak.url: create_eigenschappen_document(zen)
+            zen[0].zaak: create_eigenschappen_document(zen)
             for zen in list_of_eigenschappen
             if zen
         }

--- a/backend/src/zac/elasticsearch/searches.py
+++ b/backend/src/zac/elasticsearch/searches.py
@@ -156,7 +156,9 @@ def search(
     return response.hits
 
 
-def autocomplete_zaak_search(identificatie: str) -> List[ZaakDocument]:
+def autocomplete_zaak_search(
+    user: User, identificatie: str, only_allowed: bool = True
+) -> List[ZaakDocument]:
     search = ZaakDocument.search().query(
         Regexp(
             identificatie={
@@ -165,5 +167,8 @@ def autocomplete_zaak_search(identificatie: str) -> List[ZaakDocument]:
             }
         )
     )
+    if only_allowed:
+        search = search.filter(query_allowed_for_user(user))
+
     response = search.execute()
     return response.hits

--- a/backend/src/zac/elasticsearch/tests/test_index_zaken.py
+++ b/backend/src/zac/elasticsearch/tests/test_index_zaken.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from django.core.management import call_command
-from django.test import TestCase
 
 import requests_mock
+from rest_framework.test import APITransactionTestCase
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 from zgw_consumers.constants import APITypes
 from zgw_consumers.models import Service
@@ -19,10 +19,9 @@ ZAKEN_ROOT = "https://api.zaken.nl/api/v1/"
 
 
 @requests_mock.Mocker()
-class IndexZakenTests(ClearCachesMixin, ESMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
+class IndexZakenTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
+    def setUp(self):
+        super().setUp()
 
         Service.objects.create(api_type=APITypes.ztc, api_root=CATALOGI_ROOT)
         Service.objects.create(api_type=APITypes.zrc, api_root=ZAKEN_ROOT)
@@ -584,20 +583,6 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, TestCase):
 
     def test_index_zaken_with_status(self, m):
         # mock API requests
-        status = f"{ZAKEN_ROOT}statussen/dd4573d0-4d99-4e90-a05c-e08911e8673e"
-        statustype = f"{CATALOGI_ROOT}statustypen/c612f300-8e16-4811-84f4-78c99fdebe74"
-        status_response = generate_oas_component(
-            "zrc",
-            "schemas/Status",
-            url=status,
-            statustype=statustype,
-            statustoelichting="some-statustoelichting",
-        )
-        statustype_response = generate_oas_component(
-            "ztc",
-            "schemas/StatusType",
-            url=statustype,
-        )
         mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
         mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
         zaaktype = generate_oas_component(
@@ -614,7 +599,20 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, TestCase):
             identificatie="ZAAK1",
             vertrouwelijkheidaanduiding="zaakvertrouwelijk",
             eigenschappen=[],
-            status=status,
+            status=f"{ZAKEN_ROOT}statussen/dd4573d0-4d99-4e90-a05c-e08911e8673e",
+        )
+        status_response = generate_oas_component(
+            "zrc",
+            "schemas/Status",
+            url=f"{ZAKEN_ROOT}statussen/dd4573d0-4d99-4e90-a05c-e08911e8673e",
+            statustype=f"{CATALOGI_ROOT}statustypen/c612f300-8e16-4811-84f4-78c99fdebe74",
+            statustoelichting="some-statustoelichting",
+            zaak=zaak["url"],
+        )
+        statustype_response = generate_oas_component(
+            "ztc",
+            "schemas/StatusType",
+            url=f"{CATALOGI_ROOT}statustypen/c612f300-8e16-4811-84f4-78c99fdebe74",
         )
         m.get(
             f"{CATALOGI_ROOT}zaaktypen",
@@ -637,8 +635,14 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, TestCase):
             f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak['url']}", json=paginated_response([])
         )
         m.get(zaaktype["url"], json=zaaktype)
-        m.get(status, json=status_response)
-        m.get(statustype, json=statustype_response)
+        m.get(
+            f"{ZAKEN_ROOT}statussen/dd4573d0-4d99-4e90-a05c-e08911e8673e",
+            json=status_response,
+        )
+        m.get(
+            f"{CATALOGI_ROOT}statustypen/c612f300-8e16-4811-84f4-78c99fdebe74",
+            json=statustype_response,
+        )
         call_command("index_zaken")
 
         # check zaak_document exists

--- a/backend/src/zac/elasticsearch/tests/test_index_zaken.py
+++ b/backend/src/zac/elasticsearch/tests/test_index_zaken.py
@@ -1,3 +1,5 @@
+from io import StringIO
+
 from django.conf import settings
 from django.core.management import call_command
 
@@ -66,7 +68,7 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
             f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak['url']}", json=paginated_response([])
         )
         m.get(zaaktype["url"], json=zaaktype)
-        call_command("index_zaken")
+        call_command("index_zaken", stdout=StringIO())
 
         # check zaak_document exists
         zaak_document = ZaakDocument.get(id="a522d30c-6c10-47fe-82e3-e9f524c14ca8")
@@ -160,7 +162,7 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
             f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak['url']}", json=paginated_response([])
         )
         m.get(zaaktype["url"], json=zaaktype)
-        call_command("index_zaken")
+        call_command("index_zaken", stdout=StringIO())
 
         # check zaak_document exists
         zaak_document = ZaakDocument.get(id="69e98129-1f0d-497f-bbfb-84b88137edbc")
@@ -259,7 +261,7 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
             f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak['url']}", json=paginated_response([])
         )
         m.get(zaaktype["url"], json=zaaktype)
-        call_command("index_zaken")
+        call_command("index_zaken", stdout=StringIO())
 
         # check zaak_document exists
         zaak_document = ZaakDocument.get(id="69e98129-1f0d-497f-bbfb-84b88137edbc")
@@ -428,7 +430,7 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
             f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak['url']}", json=paginated_response([])
         )
         m.get(zaaktype["url"], json=zaaktype)
-        call_command("index_zaken")
+        call_command("index_zaken", stdout=StringIO())
 
         # check zaak_document exists
         zaak_document = ZaakDocument.get(id="a522d30c-6c10-47fe-82e3-e9f524c14ca8")
@@ -547,7 +549,7 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
             f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak['url']}", json=paginated_response([])
         )
         m.get(zaaktype["url"], json=zaaktype)
-        call_command("index_zaken")
+        call_command("index_zaken", stdout=StringIO())
 
         # check zaak_document exists
         zaak_document = ZaakDocument.get(id="a522d30c-6c10-47fe-82e3-e9f524c14ca8")
@@ -643,7 +645,7 @@ class IndexZakenTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
             f"{CATALOGI_ROOT}statustypen/c612f300-8e16-4811-84f4-78c99fdebe74",
             json=statustype_response,
         )
-        call_command("index_zaken")
+        call_command("index_zaken", stdout=StringIO())
 
         # check zaak_document exists
         zaak_document = ZaakDocument.get(id="a522d30c-6c10-47fe-82e3-e9f524c14ca8")

--- a/backend/src/zac/elasticsearch/tests/utils.py
+++ b/backend/src/zac/elasticsearch/tests/utils.py
@@ -2,11 +2,11 @@ from django.conf import settings
 
 from elasticsearch_dsl import Index
 from zgw_consumers.api_models.base import factory
+from zgw_consumers.api_models.catalogi import ZaakType
 
-from zac.core.rollen import Rol
 from zgw.models.zrc import Zaak
 
-from ..api import append_rol_to_document, create_zaak_document
+from ..api import create_zaak_document, create_zaaktype_document
 from ..documents import ZaakDocument
 
 
@@ -27,13 +27,13 @@ class ESMixin:
     def create_zaak_document(zaak):
         if not isinstance(zaak, Zaak):
             zaak = factory(Zaak, zaak)
-        create_zaak_document(zaak)
+        return create_zaak_document(zaak)
 
     @staticmethod
-    def add_rol_to_document(rol):
-        if not isinstance(rol, Rol):
-            rol = factory(Rol, rol)
-        append_rol_to_document(rol)
+    def create_zaaktype_document(zaaktype):
+        if not isinstance(zaaktype, ZaakType):
+            zaaktype = factory(ZaakType, zaaktype)
+        return create_zaaktype_document(zaaktype)
 
     def setUp(self):
         super().setUp()

--- a/backend/src/zac/notifications/handlers.py
+++ b/backend/src/zac/notifications/handlers.py
@@ -18,7 +18,9 @@ from zac.core.services import (
     update_medewerker_identificatie_rol,
 )
 from zac.elasticsearch.api import (
+    create_status_document,
     create_zaak_document,
+    create_zaaktype_document,
     delete_zaak_document,
     update_eigenschappen_in_zaak_document,
     update_rollen_in_zaak_document,
@@ -79,7 +81,10 @@ class ZakenHandler:
         zaak = self._retrieve_zaak(zaak_url)
         invalidate_zaak_list_cache(client, zaak)
         # index in ES
-        create_zaak_document(zaak)
+        zaak_document = create_zaak_document(zaak)
+        zaak_document.zaaktype = create_zaaktype_document(zaak.zaaktype)
+        zaak_document.status = create_status_document(zaak.status)
+        zaak_document.save()
 
     def _handle_zaak_destroy(self, zaak_url: str):
         Activity.objects.filter(zaak=zaak_url).delete()

--- a/backend/src/zac/notifications/tests/test_rol_created.py
+++ b/backend/src/zac/notifications/tests/test_rol_created.py
@@ -84,6 +84,8 @@ class RolCreatedTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
         rm.get(STATUSTYPE, json=STATUSTYPE_RESPONSE)
         rm.get(f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak.url}", json=paginated_response([]))
         zaak_document = create_zaak_document(zaak)
+        zaak_document.save()
+        self.refresh_index()
 
         self.assertEqual(zaak_document.rollen, [])
 
@@ -166,6 +168,8 @@ class RolCreatedTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
         rm.get(f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak.url}", json=paginated_response([]))
         zaak.zaaktype = factory(ZaakType, ZAAKTYPE_RESPONSE)
         zaak_document = create_zaak_document(zaak)
+        zaak_document.save()
+        self.refresh_index()
 
         self.client.force_authenticate(user=user)
         path = reverse("notifications:callback")
@@ -248,6 +252,8 @@ class RolCreatedTests(ClearCachesMixin, ESMixin, APITransactionTestCase):
         rol_2 = factory(Rol, rol_new)
         rm.get(f"{ZAKEN_ROOT}zaakobjecten?zaak={zaak.url}", json=paginated_response([]))
         zaak_document = create_zaak_document(zaak)
+        zaak_document.save()
+        self.refresh_index()
         self.assertEqual(zaak_document.rollen, [])
 
         self.client.force_authenticate(user=user)

--- a/backend/src/zac/notifications/tests/test_status_created.py
+++ b/backend/src/zac/notifications/tests/test_status_created.py
@@ -69,7 +69,7 @@ class StatusCreatedTests(ESMixin, APITestCase):
 
     @patch("zac.core.services.fetch_zaaktype", return_value=None)
     @patch("zac.elasticsearch.api.get_zaakobjecten", return_value=[])
-    def test_find_zaak_resultaat_created(self, rm, *mocks):
+    def test_find_zaak_status_created(self, rm, *mocks):
         mock_service_oas_get(rm, f"{ZAKEN_ROOT}", "zaken")
         mock_service_oas_get(rm, "https://some.ztc.nl/api/v1/", "ztc")
         rm.get(ZAAK, json=ZAAK_RESPONSE)

--- a/backend/src/zac/notifications/tests/test_zaak_destroyed.py
+++ b/backend/src/zac/notifications/tests/test_zaak_destroyed.py
@@ -7,6 +7,7 @@ import requests_mock
 from rest_framework import status
 from rest_framework.test import APITestCase
 from zgw_consumers.api_models.base import factory
+from zgw_consumers.api_models.catalogi import ZaakType
 from zgw_consumers.models import APITypes, Service
 from zgw_consumers.test import mock_service_oas_get
 
@@ -92,9 +93,16 @@ class ZaakDestroyedTests(ESMixin, APITestCase):
         path = reverse("notifications:callback")
 
         # create zaak document in ES
-        zaak = factory(Zaak, ZAAK_RESPONSE)
+        zaak = factory(
+            Zaak, {**ZAAK_RESPONSE, "zaaktype": factory(ZaakType, ZAAKTYPE_RESPONSE)}
+        )
         zaak_document = create_zaak_document(zaak)
-        self.assertEqual(zaak_document.meta.id, "f3ff2713-2f53-42ff-a154-16842309ad60")
+        self.refresh_index()
+
+        zaak_document.save()
+        self.assertEqual(
+            str(zaak_document.meta.id), "f3ff2713-2f53-42ff-a154-16842309ad60"
+        )
 
         response = self.client.post(path, NOTIFICATION)
 

--- a/backend/src/zac/notifications/tests/test_zaakeigenschap_changed.py
+++ b/backend/src/zac/notifications/tests/test_zaakeigenschap_changed.py
@@ -13,7 +13,7 @@ from zgw_consumers.test import generate_oas_component
 
 from zac.accounts.models import User
 from zac.core.tests.utils import ClearCachesMixin
-from zac.elasticsearch.api import create_zaak_document
+from zac.elasticsearch.api import create_zaak_document, create_zaaktype_document
 from zac.elasticsearch.documents import ZaakDocument
 from zac.elasticsearch.tests.utils import ESMixin
 from zac.tests.utils import paginated_response
@@ -113,6 +113,10 @@ class ZaakEigenschapChangedTests(ClearCachesMixin, ESMixin, APITransactionTestCa
         zaak = factory(Zaak, ZAAK_RESPONSE)
         zaak.zaaktype = factory(ZaakType, ZAAKTYPE_RESPONSE)
         zaak_document = create_zaak_document(zaak)
+        zaak_document.zaaktype = create_zaaktype_document(zaak.zaaktype)
+        zaak_document.save()
+        self.refresh_index()
+
         self.assertEqual(zaak_document.eigenschappen, {})
 
         user = User.objects.create(
@@ -159,7 +163,10 @@ class ZaakEigenschapChangedTests(ClearCachesMixin, ESMixin, APITransactionTestCa
         zaak = factory(Zaak, ZAAK_RESPONSE)
         zaak.zaaktype = factory(ZaakType, ZAAKTYPE_RESPONSE)
         zaak_document = create_zaak_document(zaak)
+        zaak_document.zaaktype = create_zaaktype_document(zaak.zaaktype)
         zaak_document.eigenschappen = {"tekst": {"propname": "propvalue"}}
+        zaak_document.save()
+        self.refresh_index()
 
         response = self.client.post(path, NOTIFICATION_DESTROY)
 

--- a/backend/src/zac/notifications/tests/utils.py
+++ b/backend/src/zac/notifications/tests/utils.py
@@ -45,7 +45,7 @@ ZAAK_RESPONSE = {
     "uiterlijke_einddatum_afdoening": None,
     "publicatiedatum": None,
     "vertrouwelijkheidaanduiding": "geheim",
-    "status": STATUS,
+    "status": None,
     "relevante_andere_zaken": [],
     "zaakgeometrie": None,
 }


### PR DESCRIPTION
Related to issue: #413.
I think the creation of elasticsearch documents should be separated from the saving and indexing of those documents. 

This is relevant for the bulk API of elasticsearch as well as making the code a little bit easier to handle (although more verbose). The creation and appending of inner docs is more explicit and the purpose of the related functions a bit more clear and aligned.



Performance changes (on local machine) based on ~6300 zaken with related objects.

- Baseline:
> - Time: ~3000 seconds
> - Peak memory usage of python process: ![baseline_index](https://user-images.githubusercontent.com/52245527/131112641-0c34a46d-083e-4749-891d-c561ea8aad4a.png)
- Bulk (without batch):
> - Time: ~700 seconds
> - Peak memory usage of python process: ![bulk_index](https://user-images.githubusercontent.com/52245527/131112860-142e10f9-937c-4bbf-b68d-b894aac0dff5.png)
- Bulk (with batch):
> - Time: ~1000 seconds
> - Peak memory usage of python process:![bulk_batch](https://user-images.githubusercontent.com/52245527/131112886-a15d6ce2-ed5b-4b3f-a739-e4a7afe3832a.png)
