### PR TITLE
add DELETE endpoint for zaak objects

### DIFF
--- a/backend/src/zac/core/api/bff_urls.py
+++ b/backend/src/zac/core/api/bff_urls.py
@@ -16,7 +16,7 @@ from .views import (
     ZaakDocumentView,
     ZaakEigenschapDetailView,
     ZaakEigenschappenView,
-    ZaakObjectCreateView,
+    ZaakObjectChangeView,
     ZaakObjectsView,
     ZaakRolesView,
     ZaakStatusesView,
@@ -104,7 +104,7 @@ urlpatterns = [
     ),
     path(
         "zaakobjects",
-        ZaakObjectCreateView.as_view(),
+        ZaakObjectChangeView.as_view(),
         name="zaakobject-create",
     ),
     path("statustypes", StatusTypenView.as_view(), name="statustypen-list"),

--- a/backend/src/zac/core/api/filters.py
+++ b/backend/src/zac/core/api/filters.py
@@ -35,3 +35,11 @@ class ZaakEigenschappenFilterSet(ApiFilterSet):
     url = fields.URLField(
         required=True, help_text=_("URL reference of ZAAK EIGENSCHAP in ZAKEN API")
     )
+
+
+class ZaakObjectFilterSet(ApiFilterSet):
+    # filtering is done in viewset.get_object() method.
+    # This filterset is used just to validate query params
+    url = fields.URLField(
+        required=True, help_text=_("URL reference of ZAAK OBJECT in ZAKEN API")
+    )

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -916,11 +916,8 @@ class ZaakObjectChangeView(views.APIView):
         tags=["objects"],
     )
     def post(self, request):
-        serializer = self.serializer_class(request.data)
-        serializer.is_valid(raise_exception=True)
-
         # check permissions
-        zaak_url = serializer.data["zaak"]
+        zaak_url = request.data["zaak"]
         zaak = get_zaak(zaak_url=zaak_url)
         self.check_object_permissions(self.request, zaak)
 

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -916,6 +916,14 @@ class ZaakObjectChangeView(views.APIView):
         tags=["objects"],
     )
     def post(self, request):
+        serializer = self.serializer_class(request.data)
+        serializer.is_valid(raise_exception=True)
+
+        # check permissions
+        zaak_url = serializer.data["zaak"]
+        zaak = get_zaak(zaak_url=zaak_url)
+        self.check_object_permissions(self.request, zaak)
+
         try:
             created_zaakobject = relate_object_to_zaak(request.data)
         except ClientError as exc:

--- a/backend/src/zac/core/services.py
+++ b/backend/src/zac/core/services.py
@@ -1176,3 +1176,15 @@ def relate_object_to_zaak(relation_data: dict) -> dict:
         relation_data,
     )
     return response
+
+
+def fetch_zaak_object(zaak_object_url: str):
+    client = _client_from_url(zaak_object_url)
+    zaak_object = client.retrieve("zaakobject", url=zaak_object_url)
+    zaak_object = factory(ZaakObject, zaak_object)
+    return zaak_object
+
+
+def delete_zaak_object(zaak_object_url: str):
+    client = _client_from_url(zaak_object_url)
+    client.delete("zaakobject", url=zaak_object_url)


### PR DESCRIPTION
Issue - https://github.com/GemeenteUtrecht/ZGW/issues/900

I don't think that PATCH or PUT endpoint is needed here. Despite we now have PATCH support in Zaken API, it doesn't include object field, which can't be changed. So we can't change the object in the zaakobject. To do so you indeed need to delete the old object and to create the new one. It's the only way which is supported by Zaken API.