### PR TITLE
:bug: Fix document versioning on zaak detail

### DIFF
--- a/backend/src/zac/core/api/tests/test_zaak_documents.py
+++ b/backend/src/zac/core/api/tests/test_zaak_documents.py
@@ -54,8 +54,7 @@ class ZaakDocumentsResponseTests(APITransactionTestCase):
         super().setUp()
         self.user = SuperUserFactory.create()
 
-    @patch("zac.core.api.views.get_review_requests", return_value=[])
-    def test_get_zaak_documents(self, m, *other_mocks):
+    def test_get_zaak_documents(self, m):
         self.client.force_authenticate(user=self.user)
 
         Service.objects.create(api_type=APITypes.ztc, api_root=CATALOGI_ROOT)
@@ -170,8 +169,7 @@ class ZaakDocumentsResponseTests(APITransactionTestCase):
         ]
         self.assertEqual(response_data, expected)
 
-    @patch("zac.core.api.views.get_review_requests", return_value=[])
-    def test_no_documents(self, m, *other_mocks):
+    def test_no_documents(self, m):
         self.client.force_authenticate(user=self.user)
 
         Service.objects.create(api_type=APITypes.ztc, api_root=CATALOGI_ROOT)
@@ -258,10 +256,6 @@ class ZaakDocumentsPermissionTests(ClearCachesMixin, APITestCase):
         zaak.zaaktype = factory(ZaakType, cls.zaaktype)
         cls.find_zaak_patcher = patch("zac.core.api.views.find_zaak", return_value=zaak)
 
-        cls.get_review_requests_patcher = patch(
-            "zac.core.api.views.get_review_requests", return_value=[]
-        )
-
         Service.objects.create(api_type=APITypes.drc, api_root=DOCUMENTS_ROOT)
 
         cls.documenttype = generate_oas_component(
@@ -322,9 +316,6 @@ class ZaakDocumentsPermissionTests(ClearCachesMixin, APITestCase):
 
         self.find_zaak_patcher.start()
         self.addCleanup(self.find_zaak_patcher.stop)
-
-        self.get_review_requests_patcher.start()
-        self.addCleanup(self.get_review_requests_patcher.stop)
 
         self.get_open_documenten_patcher.start()
         self.addCleanup(self.get_open_documenten_patcher.stop)

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -35,7 +35,6 @@ from zgw_consumers.models import Service
 from zac.accounts.models import User, UserAtomicPermission
 from zac.contrib.brp.api import fetch_extrainfo_np
 from zac.contrib.dowc.api import get_open_documenten
-from zac.contrib.kownsl.api import get_review_requests, retrieve_advices
 from zac.core.services import (
     fetch_objecttype_version,
     fetch_objecttypes,
@@ -495,18 +494,6 @@ class ListZaakDocumentsView(GetZaakMixin, views.APIView):
 
     def get(self, request, *args, **kwargs):
         zaak = self.get_object()
-
-        review_requests = get_review_requests(zaak)
-
-        with parallel() as executor:
-            _advices = executor.map(
-                lambda rr: retrieve_advices(rr) if rr else [],
-                [rr if rr.num_advices else None for rr in review_requests],
-            )
-
-            for rr, rr_advices in zip(review_requests, _advices):
-                rr.advices = rr_advices
-
         documents, gone = get_documenten(zaak)
         filtered_documenten = filter_documenten_for_permissions(documents, request)
         resolved_documenten = resolve_documenten_informatieobjecttypen(

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -73,7 +73,7 @@ from ..services import (
     resolve_documenten_informatieobjecttypen,
     zet_status,
 )
-from ..views.utils import filter_documenten_for_permissions, get_source_doc_versions
+from ..views.utils import filter_documenten_for_permissions
 from ..zaakobjecten import GROUPS, ZaakObjectGroup, noop
 from .data import VertrouwelijkheidsAanduidingData
 from .filters import (
@@ -507,8 +507,7 @@ class ListZaakDocumentsView(GetZaakMixin, views.APIView):
             for rr, rr_advices in zip(review_requests, _advices):
                 rr.advices = rr_advices
 
-        doc_versions = get_source_doc_versions(review_requests)
-        documents, gone = get_documenten(zaak, doc_versions)
+        documents, gone = get_documenten(zaak)
         filtered_documenten = filter_documenten_for_permissions(documents, request)
         resolved_documenten = resolve_documenten_informatieobjecttypen(
             filtered_documenten


### PR DESCRIPTION
Before we allowed users to update the documents on the zaak detail page and the advice page, on top of the approval page, we wanted to prevent users from seeing documents that were still being approved and updated in approval processes (for example). 

Since allowing users to edit documents on the zaak detail as well as the advice page, this has become irrelevant and wrong document versions are now shown. This should fix that. 

I previously thought it was a cache problem, but I don't think it is as cache gets invalidated on a document level by the submission of the advice/approval and that's also how `get_documenten` is cached (on a per document basis rather than all documents together).

Fixes: https://github.com/GemeenteUtrecht/zaakafhandelcomponent/issues/411