### PR TITLE
add url attribute to POST document endpoint

### DIFF
--- a/backend/src/zac/core/api/bff_urls.py
+++ b/backend/src/zac/core/api/bff_urls.py
@@ -51,7 +51,7 @@ urlpatterns = [
         name="zaak-documents",
     ),
     path(
-        "cases/<str:bronorganisatie>/<str:identificatie>/document",
+        "cases/document",
         ZaakDocumentView.as_view(),
         name="zaak-document",
     ),

--- a/backend/src/zac/core/api/serializers.py
+++ b/backend/src/zac/core/api/serializers.py
@@ -2,13 +2,13 @@ from decimal import ROUND_05UP
 from typing import Optional
 
 from django.conf import settings
-from django.contrib.auth.models import Group
 from django.core.validators import RegexValidator
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext as _
 
 from furl import furl
 from rest_framework import serializers
+from zds_client.client import ClientError
 from zgw_consumers.api_models.catalogi import (
     EIGENSCHAP_FORMATEN,
     Eigenschap,
@@ -34,7 +34,13 @@ from zac.api.proxy import ProxySerializer
 from zac.contrib.dowc.constants import DocFileTypes
 from zac.contrib.dowc.fields import DowcUrlFieldReadOnly
 from zac.core.rollen import Rol
-from zac.core.services import fetch_zaaktype, get_documenten, get_statustypen, get_zaak
+from zac.core.services import (
+    fetch_zaaktype,
+    get_document,
+    get_documenten,
+    get_statustypen,
+    get_zaak,
+)
 from zgw.models.zrc import Zaak
 
 from ..zaakobjecten import ZaakObjectGroup
@@ -102,20 +108,54 @@ class GetZaakDocumentSerializer(APIModelSerializer):
 
 
 class AddZaakDocumentSerializer(serializers.Serializer):
-    beschrijving = serializers.CharField(required=False)
-    file = serializers.FileField(required=True, use_url=False)
-    informatieobjecttype = serializers.URLField(required=True)
+    beschrijving = serializers.CharField(
+        required=False, help_text=_("Description of the document")
+    )
+    file = serializers.FileField(
+        required=False,
+        use_url=False,
+        help_text=_("Content of the document. Mutually exclusive with `url` attribute"),
+    )
+    informatieobjecttype = serializers.URLField(
+        required=False,
+        help_text=_(
+            "URL of informatiobjecttype in Catalogi API. Required if `file` is provided"
+        ),
+    )
+    url = serializers.URLField(
+        required=False,
+        help_text=_(
+            "URL of document in Documenten API. Mutually exclusive with `file` attribute"
+        ),
+    )
     zaak = serializers.URLField(
         required=True,
-        help_text=_("URL of the case."),
+        help_text=_("URL of the zaak in Zaken API"),
         allow_blank=False,
     )
 
     def validate(self, data):
-        zaak = data["zaak"]
+        zaak = data.get("zaak")
         informatieobjecttype_url = data.get("informatieobjecttype")
+        document_url = data.get("url")
+        file = data.get("file")
 
-        if zaak and informatieobjecttype_url:
+        if document_url and file:
+            raise serializers.ValidationError(
+                "'url' and 'file' are mutually exclusive and can't be provided together."
+            )
+
+        if not document_url and not file:
+            raise serializers.ValidationError(
+                "Either 'url' or 'file' should be provided."
+            )
+
+        if file:
+            if not informatieobjecttype_url:
+                raise serializers.ValidationError(
+                    "'informatieobjecttype' is required when 'file' is provided"
+                )
+
             informatieobjecttypen = get_informatieobjecttypen_for_zaak(zaak)
             present = any(
                 iot
@@ -128,6 +168,12 @@ class AddZaakDocumentSerializer(serializers.Serializer):
                 )
 
         return data
+
+    def validate_url(self, value):
+        try:
+            get_document(value)
+        except ClientError as exc:
+            raise serializers.ValidationError(detail=exc.args)
 
 
 class UpdateZaakDocumentSerializer(serializers.Serializer):

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -592,8 +592,17 @@ class ZaakDocumentView(views.APIView):
         serializer.is_valid(raise_exception=True)
 
         zaak = get_zaak(zaak_url=serializer.validated_data["zaak"])
-        document_data = self.get_document_data(serializer.validated_data, zaak)
-        document = create_document(document_data)
+        url = serializer.validated_data.get("url")
+
+        if url:
+            # Document already exists, don't need to create it
+            document = get_document(url)
+
+        else:
+            # create document in Documenten API
+            document_data = self.get_document_data(serializer.validated_data, zaak)
+            document = create_document(document_data)
+
         relate_document_to_zaak(document.url, zaak.url)
         document.informatieobjecttype = get_informatieobjecttype(
             document.informatieobjecttype


### PR DESCRIPTION
Issue #435  (backend)

---
**NOTE:**


The PR has a breaking change: 
* the path of the POST/PATCH endpoint `/api/core/cases/{bronorganisatie}/{identificatie}/document` is changed into `/api/core/cases/document` 

---
