### PR TITLE
:sparkles: Add max_workers argument to index_zaken command

### DIFF
--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -2,6 +2,7 @@ from typing import Dict, Iterator, List
 
 from django.conf import settings
 from django.core.management import BaseCommand
+from django.core.management.base import CommandParser
 
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl import Index
@@ -42,7 +43,16 @@ from ...documents import (
 class Command(BaseCommand):
     help = "Create documents in ES by indexing all zaken from ZAKEN API"
 
+    def add_arguments(self, parser: CommandParser) -> None:
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--max_workers",
+            type=int,
+            help="Indicates the max number of parallel workers (for memory management). Defaults to 4.",
+        )
+
     def handle(self, **options):
+        self.max_workers = options.get("max_workers", 4)
         self.clear_zaken_index()
         bulk(
             connections.get_connection(),
@@ -104,7 +114,7 @@ class Command(BaseCommand):
         unfetched_zaaktypen = {
             zaak.zaaktype for zaak in zaken if isinstance(zaak.zaaktype, str)
         }
-        with parallel(max_workers=10) as executor:
+        with parallel(max_workers=self.max_workers) as executor:
             results = executor.map(fetch_zaaktype, unfetched_zaaktypen)
         zaaktypen = {zaaktype.url: zaaktype for zaaktype in list(results)}
 
@@ -118,7 +128,7 @@ class Command(BaseCommand):
         return zaaktype_documenten
 
     def create_status_documenten(self, zaken: List[Zaak]) -> Dict[str, StatusDocument]:
-        with parallel(max_workers=10) as executor:
+        with parallel(max_workers=self.max_workers) as executor:
             results = executor.map(get_status, zaken)
         status_documenten = {
             status.zaak: create_status_document(status)
@@ -131,7 +141,7 @@ class Command(BaseCommand):
         return status_documenten
 
     def create_rollen_documenten(self, zaken: List[Zaak]) -> Dict[str, RolDocument]:
-        with parallel(max_workers=10) as executor:
+        with parallel(max_workers=self.max_workers) as executor:
             results = list(executor.map(get_rollen, zaken))
 
         list_of_rollen = [rollen for rollen in results if rollen]
@@ -149,7 +159,7 @@ class Command(BaseCommand):
         self, zaken: List[Zaak]
     ) -> Dict[str, EigenschapDocument]:
         # Prefetch zaakeigenschappen
-        with parallel(max_workers=10) as executor:
+        with parallel(max_workers=self.max_workers) as executor:
             list_of_eigenschappen = list(executor.map(get_zaak_eigenschappen, zaken))
 
         eigenschappen_documenten = {
@@ -166,7 +176,7 @@ class Command(BaseCommand):
         self, zaken: List[Zaak]
     ) -> Dict[str, ZaakObjectDocument]:
         # Prefetch zaakobjecten
-        with parallel(max_workers=10) as executor:
+        with parallel(max_workers=self.max_workers) as executor:
             list_of_zon = list(executor.map(get_zaakobjecten, zaken))
 
         zaakobjecten_documenten = {

--- a/backend/src/zac/elasticsearch/management/commands/index_zaken.py
+++ b/backend/src/zac/elasticsearch/management/commands/index_zaken.py
@@ -49,10 +49,11 @@ class Command(BaseCommand):
             "--max_workers",
             type=int,
             help="Indicates the max number of parallel workers (for memory management). Defaults to 4.",
+            default=4,
         )
 
     def handle(self, **options):
-        self.max_workers = options.get("max_workers", 4)
+        self.max_workers = options["max_workers"]
         self.clear_zaken_index()
         bulk(
             connections.get_connection(),


### PR DESCRIPTION
This seems to be the most straightforward method of keeping memory use stable and in check while still having better performance than original (~200% faster but also >200% slower than keeping max_workers at 10). 

I've scripted the indexing to be run with a range of max workers so you can see changes to the real and virtual memory and the total time until completion in each case.

You can easily see that there is no rampant increase in memory use throughout the entire indexing. Virtual memory increases the most. Using docker-compose and the following docker-compose.yml I'm actually unable to reproduce any OOM errors at all even though virtual memory is 0 in these cases.

```
version: '3.4'

services:
  db:
    image: postgres:11
    environment:
      - POSTGRES_USER=${DB_USER:-postgres}
      - POSTGRES_PASSWORD=${DB_PASSWORD:-postgres}
    volumes:
      - postgres_data:/var/lib/postgresql/data

  redis:
    image: redis:5-alpine

  elasticsearch:
    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.2
    environment:
      - discovery.type=single-node
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
    volumes:
      - es_data:/usr/share/elasticsearch/data
    # expose to the host machine so that we can use docker ES for development
    ports:
      - 9200:9200
      - 9300:9300

  web:
    image: scrumteamzgw/zaakafhandelcomponent:${TAG:-latest}
    build: .
    environment:
      - AUTORELOAD=true
      - DJANGO_SETTINGS_MODULE=zac.conf.docker
      - SECRET_KEY=${SECRET_KEY:-changeme}
      - IS_HTTPS=0
      - ALLOWED_HOSTS=localhost
      - REDIS_HOST=redis
      - ES_HOST=elasticsearch
      - USE_REDIS_CACHE=True
      - CACHE_DEFAULT=redis:6379/0
      - CACHE_AXES=redis:6379/0
      - CACHE_OAS=redis:6379/1
      - CACHE_SESSIONS=redis:6379/1
      - CORS_HEADERS_ENABLED=True
      - DEBUG=True
    # expose backend port for frontend development
    ports:
      - 8000:8000
    depends_on:
      - db
      - redis
      - elasticsearch
    memswap_limit: 1G
    mem_limit: 1G
    mem_reservation: 1G

volumes:
  postgres_data:
  es_data:
```
**Max_workers = 50**
![index_zaken_max_workers_50](https://user-images.githubusercontent.com/52245527/134180937-f01d3503-cb8c-4f65-8e78-93006f800acb.png)
**Max_workers = 25**
![index_zaken_max_workers_25](https://user-images.githubusercontent.com/52245527/134181113-3cda1973-b6f5-4889-a557-38534a6ff91e.png)
**Max_workers = 10**
![index_zaken_max_workers_10](https://user-images.githubusercontent.com/52245527/134181125-bc8e9a2c-4bda-4ae2-b641-6c72cdabba77.png)
**Max_workers = 7**
![index_zaken_max_workers_7](https://user-images.githubusercontent.com/52245527/134185145-feceea6a-d230-4ced-8ac0-3f656498fa45.png)
**Max_workers = 5**
![index_zaken_max_workers_5](https://user-images.githubusercontent.com/52245527/134188633-fe575372-ce84-4e5f-8977-e2b973bded80.png)
**Max_workers = 4**
![index_zaken_max_workers_4](https://user-images.githubusercontent.com/52245527/134192951-1ee4a653-eb25-49eb-8f66-1eb2e365f941.png)