### PR TITLE
Make 'reden' optional when patching zaak

### DIFF
--- a/backend/src/zac/core/api/tests/test_zaak_detail.py
+++ b/backend/src/zac/core/api/tests/test_zaak_detail.py
@@ -272,7 +272,7 @@ class ZaakDetailResponseTests(ESMixin, ClearCachesMixin, APITestCase):
         self.assertIsNone(cache.get(cache_find_key))
 
     @freeze_time("2020-12-26T12:00:00Z")
-    def test_change_invalid(self, m):
+    def test_change_va_without_reden_invalid(self, m):
         mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
         mock_resource_get(m, self.zaaktype)
         mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
@@ -286,16 +286,75 @@ class ZaakDetailResponseTests(ESMixin, ClearCachesMixin, APITestCase):
         response = self.client.patch(
             self.detail_url,
             {
-                "vertrouwelijkheidaanduiding": "zo-geheim-dit",
+                "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.zeer_geheim,
             },
         )
-        self.assertEqual(response.status_code, 400)
-        response = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response["vertrouwelijkheidaanduiding"],
-            ['"zo-geheim-dit" is een ongeldige keuze.'],
+            response.json()["nonFieldErrors"],
+            ["'reden' is required when 'vertrouwelijkheidaanduiding' is changed"],
         )
-        self.assertEqual(response["reden"], ["Dit veld is vereist."])
+
+    @freeze_time("2020-12-26T12:00:00Z")
+    def test_change_va_without_reden_valid(self, m):
+        """ Update va without changing va value doesn't require reden"""
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        mock_resource_get(m, self.zaaktype)
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456782&identificatie=ZAAK-2020-0010",
+            json=paginated_response([self.zaak]),
+        )
+
+        m.patch(self.zaak["url"], status_code=status.HTTP_200_OK)
+
+        response = self.client.patch(
+            self.detail_url,
+            {
+                "vertrouwelijkheidaanduiding": self.zaak["vertrouwelijkheidaanduiding"],
+                "omschrijving": "new desc",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(m.last_request.url, self.zaak["url"])
+        self.assertEqual(
+            m.last_request.json(),
+            {
+                "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.openbaar,
+                "omschrijving": "new desc",
+            },
+        )
+        self.assertFalse("X-Audit-Toelichting" in m.last_request.headers)
+
+    def test_change_without_reden_valid(self, m):
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        mock_resource_get(m, self.zaaktype)
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456782&identificatie=ZAAK-2020-0010",
+            json=paginated_response([self.zaak]),
+        )
+
+        m.patch(self.zaak["url"], status_code=status.HTTP_200_OK)
+
+        response = self.client.patch(
+            self.detail_url,
+            {
+                "omschrijving": "new desc",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(m.last_request.url, self.zaak["url"])
+        self.assertEqual(
+            m.last_request.json(),
+            {
+                "omschrijving": "new desc",
+            },
+        )
+        self.assertFalse("X-Audit-Toelichting" in m.last_request.headers)
 
 
 class ZaakDetailPermissionTests(ESMixin, ClearCachesMixin, APITestCase):

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -233,18 +233,19 @@ class ZaakDetailView(GetZaakMixin, views.APIView):
         service = Service.get_service(zaak.url)
         client = service.build_client()
 
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(data=request.data, context={"zaak": zaak})
         serializer.is_valid(raise_exception=True)
 
         # If no errors are raised - data is valid too.
         data = {**serializer.data}
-        reden = data.pop("reden")
+        reden = data.pop("reden", None)
+        request_kwargs = {"headers": {"X-Audit-Toelichting": reden}} if reden else {}
 
         client.partial_update(
             "zaak",
             data,
             url=zaak.url,
-            request_kwargs={"headers": {"X-Audit-Toelichting": reden}},
+            request_kwargs=request_kwargs,
         )
         invalidate_zaak_cache(zaak=zaak)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
It's required now only when `vertrouwelijkheidaanduiding` is changed

Issue - GemeenteUtrecht/ZGW#941 (BE part)