### PR TITLE
:sparkles: #974 - Only show geographical search field if object type …

### DIFF
--- a/frontend/zac-ui/libs/features/search/src/lib/search-form/object-search-form/zaak-object-search-form.component.ts
+++ b/frontend/zac-ui/libs/features/search/src/lib/search-form/object-search-form/zaak-object-search-form.component.ts
@@ -103,15 +103,23 @@ export class ZaakObjectSearchFormComponent implements OnInit {
    */
   get form(): FieldConfiguration[] {
     return [
+      this.objectTypesAsFieldConfiguration(),
+      ...this.objectTypeVersionsAsFieldConfigurations(),
       {
         choices: OBJECT_SEARCH_GEOMETRY_CHOICES,
         label: 'Gebied',
         name: 'geometry',
         required: false,
         value: OBJECT_SEARCH_GEOMETRY_CHOICES[0].value,
+        activeWhen: (formGroup) => {
+          const geometryIndicators = ['adres'];
+          const objectTypeUrl = formGroup.getRawValue().objectType;
+          const objectType = this.objectTypes.find((objectType: ObjectType) => objectType.url === objectTypeUrl);
+          const objectTypeVersionUrl = objectType?.versions[objectType.versions.length - 1];
+          const objectTypeVersion = this.objectTypeVersions.find((objectTypeVersion: ObjectTypeVersion) => objectTypeVersion.url === objectTypeVersionUrl)
+          return geometryIndicators.find((indicator: string) => objectTypeVersion?.jsonSchema.properties[indicator]);
+        }
       },
-      this.objectTypesAsFieldConfiguration(),
-      ...this.objectTypeVersionsAsFieldConfigurations(),
       {
         label: 'Zoekopdracht',
         name: 'query',


### PR DESCRIPTION
…is set to an object type that contains the field "adres".

For now this only shows the field for laadpalen, but primarily acts as entry point for further refinement.