### PR TITLE
Issue/#505

### DIFF
--- a/backend/src/zac/camunda/processes.py
+++ b/backend/src/zac/camunda/processes.py
@@ -3,11 +3,11 @@ from typing import Dict, List
 from django_camunda.camunda_models import ProcessDefinition
 from django_camunda.client import Camunda, get_client
 from zgw_consumers.api_models.base import factory
+from zgw_consumers.concurrent import parallel
 
+from zac.camunda.data import ProcessInstance
+from zac.camunda.messages import get_messages
 from zac.core.camunda import get_process_tasks
-
-from .data import ProcessInstance
-from .messages import get_messages
 
 
 def get_process_definitions(definition_ids: list) -> List[ProcessDefinition]:
@@ -37,9 +37,12 @@ def add_subprocesses(
 
         sub_process_instance.parent_process = process_instance
         process_instance.sub_processes.append(sub_process_instance)
-        process_instances[sub_process_instance.id] = sub_process_instance
-
-        add_subprocesses(sub_process_instance, process_instances, client)
+        if (
+            sub_process_instance.id not in process_instances
+            or sub_process_instance != process_instances[sub_process_instance.id]
+        ):
+            process_instances[sub_process_instance.id] = sub_process_instance
+            add_subprocesses(sub_process_instance, process_instances, client)
 
 
 def get_process_instances(zaak_url: str) -> List[ProcessInstance]:
@@ -50,10 +53,17 @@ def get_process_instances(zaak_url: str) -> List[ProcessInstance]:
     process_instances = {
         data["id"]: factory(ProcessInstance, data) for data in response
     }
+    # fill in all subprocesses into the dict
+    pids = [
+        process_instance for id, process_instance in process_instances.copy().items()
+    ]
 
-    # fill in all subpocesses into the dict
-    for id, process_instance in process_instances.copy().items():
-        add_subprocesses(process_instance, process_instances, client)
+    def _add_subprocesses(pid: ProcessInstance):
+        nonlocal process_instances, client
+        add_subprocesses(pid, process_instances, client)
+
+    with parallel() as executor:
+        list(executor.map(_add_subprocesses, pids))
 
     # add definitions add user tasks
     definition_ids = [p.definition_id for p in process_instances.values()]
@@ -61,20 +71,34 @@ def get_process_instances(zaak_url: str) -> List[ProcessInstance]:
         definition.id: definition
         for definition in get_process_definitions(definition_ids)
     }
+    process_instances_without_task = []
     for id, process_instance in process_instances.items():
         process_instance.definition = definitions[process_instance.definition_id]
         if not process_instance.tasks:
-            process_instance.tasks = get_process_tasks(process_instance)
+            process_instances_without_task.append(process_instance)
+
+    with parallel() as executor:
+        results = executor.map(get_process_tasks, process_instances_without_task)
+
+    tasks = {str(_tasks[0].process_instance_id): _tasks for _tasks in results if _tasks}
+    for id, process_instance in process_instances.items():
+        if not process_instance.tasks:
+            process_instance.tasks = tasks.get(str(process_instance.id), [])
 
     # get messages only for top level processes
     top_level_processes = [
         p for p in process_instances.values() if not p.parent_process
     ]
     top_definition_ids = {p.definition_id for p in top_level_processes}
-    def_messages = {
-        definition_id: get_messages(definition_id)
-        for definition_id in top_definition_ids
-    }
+    def_messages: Dict[str, List[str]] = {}
+
+    def _get_messages(definition_id: str):
+        nonlocal def_messages
+        def_messages[definition_id] = get_messages(definition_id)
+
+    with parallel() as executor:
+        list(executor.map(_get_messages, top_definition_ids))
+
     for process in top_level_processes:
         process.messages = def_messages[process.definition_id]
 

--- a/backend/src/zac/camunda/tests/test_fetch_process_instances.py
+++ b/backend/src/zac/camunda/tests/test_fetch_process_instances.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.test.testcases import TransactionTestCase
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -22,20 +23,16 @@ CAMUNDA_URL = f"{CAMUNDA_ROOT}{CAMUNDA_API_PATH}"
     return_value=["Annuleer behandeling", "Advies vragen"],
 )
 @requests_mock.Mocker()
-class ProcessInstanceTests(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
+class ProcessInstanceTests(TransactionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
         config = CamundaConfig.get_solo()
         config.root_url = CAMUNDA_ROOT
         config.rest_api_path = CAMUNDA_API_PATH
         config.save()
 
-        cls.user = UserFactory.create()
-        cls.group = GroupFactory.create()
-
-    def setUp(self) -> None:
-        super().setUp()
+        self.user = UserFactory.create()
+        self.group = GroupFactory.create()
         self.client.force_login(self.user)
 
     def _setUpMock(self, m):


### PR DESCRIPTION
Related to #505 .

Response time is roughly decreased by ~40-80% (more so if there are a lot of subprocesses).
For zaak 1697 in zac-test.utrechtproeftuin.nl which has 10 sub processes the time is reduced from ~5.5-6 seconds to ~1.3-1.7 seconds.
For zaak 1705 in zac-test.utrechtproeftuin.nl which has 2 sub processes the time is reduced from ~1 seconds to ~0.6 seconds.

https://github.com/GemeenteUtrecht/zaakafhandelcomponent/pull/511 is a small improvement on top of this, but I think less desirable.

