### PR TITLE
Fix/no crash on empty zaak in task

### DIFF
--- a/backend/src/zac/werkvoorraad/api/views.py
+++ b/backend/src/zac/werkvoorraad/api/views.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 from django.contrib.auth.models import Group
@@ -32,6 +33,8 @@ from .utils import (
     get_camunda_group_tasks,
     get_camunda_user_tasks,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @extend_schema(summary=_("List access requests"))
@@ -133,7 +136,15 @@ class WorkStackUserTasksView(ListAPIView):
                 urls=list({tzu[1] for tzu in task_ids_and_zaak_urls}),
             )
         }
-        task_zaken = {tzu[0]: zaken.get(tzu[1]) for tzu in task_ids_and_zaak_urls}
+        task_zaken = {}
+        for tzu in task_ids_and_zaak_urls:
+            if not (zaak := zaken.get(tzu[1])):
+                logger.warning(
+                    "Couldn't find a ZAAK in Elasticsearch for task with id %s."
+                    % tzu[0]
+                )
+
+            task_zaken[tzu[0]] = zaak
 
         return [
             TaskAndCase(task=task, zaak=task_zaken[task.id])

--- a/backend/src/zac/werkvoorraad/api/views.py
+++ b/backend/src/zac/werkvoorraad/api/views.py
@@ -137,14 +137,14 @@ class WorkStackUserTasksView(ListAPIView):
             )
         }
         task_zaken = {}
-        for tzu in task_ids_and_zaak_urls:
-            if not (zaak := zaken.get(tzu[1])):
+        for task_id, zaak_url in task_ids_and_zaak_urls:
+            if not (zaak := zaken.get(zaak_url)):
                 logger.warning(
                     "Couldn't find a ZAAK in Elasticsearch for task with id %s."
-                    % tzu[0]
+                    % task_id
                 )
 
-            task_zaken[tzu[0]] = zaak
+            task_zaken[task_id] = zaak
 
         return [
             TaskAndCase(task=task, zaak=task_zaken[task.id])

--- a/backend/src/zac/werkvoorraad/api/views.py
+++ b/backend/src/zac/werkvoorraad/api/views.py
@@ -135,7 +135,11 @@ class WorkStackUserTasksView(ListAPIView):
         }
         task_zaken = {tzu[0]: zaken.get(tzu[1]) for tzu in task_ids_and_zaak_urls}
 
-        return [TaskAndCase(task=task, zaak=task_zaken[task.id]) for task in tasks]
+        return [
+            TaskAndCase(task=task, zaak=task_zaken[task.id])
+            for task in tasks
+            if task_zaken[task.id]
+        ]
 
 
 @extend_schema(summary=_("List user tasks assigned to groups related to user"))

--- a/backend/src/zac/werkvoorraad/tests/test_camunda_tasks_endpoint.py
+++ b/backend/src/zac/werkvoorraad/tests/test_camunda_tasks_endpoint.py
@@ -201,3 +201,21 @@ class CamundaTasksTests(ESMixin, APITestCase):
                 },
             ],
         )
+
+    def test_user_tasks_endpoint_zaak_is_deleted(self):
+        with patch(
+            "zac.werkvoorraad.api.views.get_zaak_url_from_context",
+            return_value=(self.task.id, self.zaak["url"]),
+        ):
+            with patch(
+                "zac.werkvoorraad.api.views.get_camunda_user_tasks",
+                return_value=[self.task],
+            ):
+                with patch(
+                    "zac.werkvoorraad.api.views.search",
+                    return_value=[],
+                ):
+                    response = self.client.get(self.user_endpoint)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data, [])

--- a/backend/src/zac/werkvoorraad/tests/test_camunda_tasks_endpoint.py
+++ b/backend/src/zac/werkvoorraad/tests/test_camunda_tasks_endpoint.py
@@ -202,7 +202,7 @@ class CamundaTasksTests(ESMixin, APITestCase):
             ],
         )
 
-    def test_user_tasks_endpoint_zaak_is_deleted(self):
+    def test_user_tasks_endpoint_zaak_cant_be_found(self):
         with patch(
             "zac.werkvoorraad.api.views.get_zaak_url_from_context",
             return_value=(self.task.id, self.zaak["url"]),


### PR DESCRIPTION
Sometimes a zaak can not be found for a task for whatever reason - these tasks should not be shown because it breaks the FE.