### PR TITLE
Fix/cascade access request

### DIFF
--- a/backend/src/zac/notifications/handlers.py
+++ b/backend/src/zac/notifications/handlers.py
@@ -2,6 +2,7 @@ from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.catalogi import ZaakType
 from zgw_consumers.api_models.zaken import Status
 
+from zac.accounts.models import AccessRequest
 from zac.accounts.permission_loaders import add_permission_for_behandelaar
 from zac.activities.models import Activity
 from zac.contrib.board.models import BoardItem
@@ -99,6 +100,8 @@ class ZakenHandler:
     def _handle_zaak_destroy(self, zaak_url: str):
         Activity.objects.filter(zaak=zaak_url).delete()
         BoardItem.objects.filter(object=zaak_url).delete()
+        AccessRequest.objects.filter(zaak=zaak_url).delete()
+
         # index in ES
         delete_zaak_document(zaak_url)
 

--- a/backend/src/zac/notifications/tests/test_zaak_destroyed.py
+++ b/backend/src/zac/notifications/tests/test_zaak_destroyed.py
@@ -11,7 +11,8 @@ from zgw_consumers.api_models.catalogi import ZaakType
 from zgw_consumers.models import APITypes, Service
 from zgw_consumers.test import mock_service_oas_get
 
-from zac.accounts.tests.factories import UserFactory
+from zac.accounts.models import AccessRequest
+from zac.accounts.tests.factories import AccessRequestFactory, UserFactory
 from zac.activities.models import Activity, Event
 from zac.activities.tests.factories import ActivityFactory, EventFactory
 from zac.contrib.board.models import BoardItem
@@ -121,3 +122,14 @@ class ZaakDestroyedTests(ESMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(BoardItem.objects.exists())
+
+    def test_access_request_deleted(self):
+        path = reverse("notifications:callback")
+        AccessRequestFactory(
+            zaak="https://some.zrc.nl/api/v1/zaken/f3ff2713-2f53-42ff-a154-16842309ad60"
+        )
+
+        response = self.client.post(path, NOTIFICATION)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(AccessRequest.objects.exists())


### PR DESCRIPTION
Access requests shouldn't exist if the zaak doesn't exist anymore for whatever reason.