### PR TITLE
:bug: #1123 - Remove spinner from property search form.

### DIFF
--- a/frontend/zac-ui/libs/features/search/src/lib/search-form/property-search-form/property-search-form.component.html
+++ b/frontend/zac-ui/libs/features/search/src/lib/search-form/property-search-form/property-search-form.component.html
@@ -1,4 +1,3 @@
-<gu-loading-indicator *ngIf="isLoading"></gu-loading-indicator>
 <form [formGroup]="searchForm">
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
Als ik het zoekscherm open in de ZAC, blijft deze altijd hangen op het draaiende spinnertje. Ik moet standaard altijd op refresh klikken om de pagina correct te kunnen zien.