### PR TITLE
:sparkles: #1317 - Fix incorrect callback when adding related object.

### DIFF
--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/gerelateerde-objecten/gerelateerde-objecten.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/gerelateerde-objecten/gerelateerde-objecten.component.ts
@@ -222,7 +222,7 @@ export class GerelateerdeObjectenComponent implements OnInit {
         .subscribe(
           () => {
             this.modalService.close(this.modalFormId);
-            this.getContextData.bind(this);
+            this.getContextData();
           },
           this.reportError.bind(this),
           () => this.isLoading = false,


### PR DESCRIPTION
Dit lost het probleem niet volledig op maar is ook een probleempje op zich. De rest van het problem is cache gerelateerd en het lijkt mij dat de backend moet wachten moet resolven totdat notificaties zijn afgehandeld/caches zijn geleegd?