### PR TITLE
:sparkles: Add last_edited_date to list zaakdocument endpoint

### DIFF
--- a/backend/src/zac/core/api/data.py
+++ b/backend/src/zac/core/api/data.py
@@ -27,7 +27,7 @@ class AuditTrailWijzigingenData(Model):
 @dataclass
 class AuditTrailData(Model):
     aanmaakdatum: datetime
-    wijzigingen: List[AuditTrailWijzigingenData]
+    wijzigingen: AuditTrailWijzigingenData
     resource_url: str
 
     @property
@@ -35,3 +35,9 @@ class AuditTrailData(Model):
         if self.wijzigingen.nieuw.version_label:
             return True
         return False
+
+    @property
+    def last_edited_date(self) -> datetime:
+        if modified := self.wijzigingen.nieuw.modified:
+            return modified
+        return self.aanmaakdatum

--- a/backend/src/zac/core/api/data.py
+++ b/backend/src/zac/core/api/data.py
@@ -1,9 +1,37 @@
 from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
 
-from zgw_consumers.api_models.base import Model
+from zgw_consumers.api_models.base import Model, factory
 
 
 @dataclass
 class VertrouwelijkheidsAanduidingData(Model):
     label: str
     value: str
+
+
+@dataclass
+class AuditTrailWijzigingsData(Model):
+    modified: Optional[datetime] = None
+    author: Optional[str] = None
+    version_label: Optional[str] = None
+
+
+@dataclass
+class AuditTrailWijzigingenData(Model):
+    oud: AuditTrailWijzigingsData
+    nieuw: AuditTrailWijzigingsData
+
+
+@dataclass
+class AuditTrailData(Model):
+    aanmaakdatum: datetime
+    wijzigingen: List[AuditTrailWijzigingenData]
+    resource_url: str
+
+    @property
+    def was_bumped(self) -> bool:
+        if self.wijzigingen.nieuw.version_label:
+            return True
+        return False

--- a/backend/src/zac/core/api/serializers.py
+++ b/backend/src/zac/core/api/serializers.py
@@ -1,4 +1,5 @@
 import pathlib
+from datetime import datetime
 from decimal import ROUND_05UP
 from typing import Optional
 
@@ -74,6 +75,7 @@ class GetZaakDocumentSerializer(APIModelSerializer):
     )
     informatieobjecttype = InformatieObjectTypeSerializer()
     current_user_is_editing = serializers.SerializerMethodField()
+    last_edited_date = serializers.SerializerMethodField()
 
     class Meta:
         model = Document
@@ -85,6 +87,7 @@ class GetZaakDocumentSerializer(APIModelSerializer):
             "current_user_is_editing",
             "identificatie",
             "informatieobjecttype",
+            "last_edited_date",
             "locked",
             "read_url",
             "titel",
@@ -105,6 +108,11 @@ class GetZaakDocumentSerializer(APIModelSerializer):
                 return True
             else:
                 return False
+        return None
+
+    def get_last_edited_date(self, obj) -> Optional[datetime]:
+        if "editing_history" in self.context:
+            return self.context["editing_history"][obj.url]
         return None
 
 

--- a/backend/src/zac/core/api/tests/test_manage_zaak_document.py
+++ b/backend/src/zac/core/api/tests/test_manage_zaak_document.py
@@ -210,7 +210,11 @@ class ZaakDocumentPermissionTests(ClearCachesMixin, APITransactionTestCase):
             "zac.core.api.views.get_open_documenten",
             return_value=[
                 DowcResponse(
-                    drc_url=document["url"], magic_url="", purpose="write", uuid=uuid4()
+                    drc_url=document["url"],
+                    magic_url="",
+                    purpose="write",
+                    uuid=uuid4(),
+                    unversioned_url="",
                 )
             ],
         ):
@@ -408,6 +412,7 @@ class ZaakDocumentPermissionTests(ClearCachesMixin, APITransactionTestCase):
                             magic_url="",
                             purpose="write",
                             uuid=uuid4(),
+                            unversioned_url="",
                         )
                     ],
                 ):
@@ -562,6 +567,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             return_value=[
                 DowcResponse(
                     drc_url=document["url"],
+                    unversioned_url="",
                     magic_url="",
                     purpose="write",
                     uuid=uuid4(),
@@ -669,6 +675,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             return_value=[
                 DowcResponse(
                     drc_url=document["url"],
+                    unversioned_url="",
                     magic_url="",
                     purpose="write",
                     uuid=uuid4(),
@@ -932,6 +939,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
                     return_value=[
                         DowcResponse(
                             drc_url=document["url"],
+                            unversioned_url="",
                             magic_url="",
                             purpose="write",
                             uuid=uuid4(),

--- a/backend/src/zac/core/api/tests/test_manage_zaak_document.py
+++ b/backend/src/zac/core/api/tests/test_manage_zaak_document.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.urls import reverse
 
@@ -20,6 +21,8 @@ from zac.accounts.tests.factories import (
     SuperUserFactory,
     UserFactory,
 )
+from zac.contrib.dowc.data import DowcResponse
+from zac.core.api.data import AuditTrailData
 from zac.core.tests.utils import ClearCachesMixin
 
 from ...models import CoreConfig
@@ -162,8 +165,8 @@ class ZaakDocumentPermissionTests(ClearCachesMixin, APITransactionTestCase):
         document = generate_oas_component(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
+            url=f"{DOCUMENTS_ROOT}enkelvoudiginformatieobjecten/0c47fe5e-4fe1-4781-8583-168e0730c9b6",
         )
-
         m.post(
             f"{DOCUMENTS_ROOT}enkelvoudiginformatieobjecten",
             json=document,
@@ -182,8 +185,42 @@ class ZaakDocumentPermissionTests(ClearCachesMixin, APITransactionTestCase):
             "file": BytesIO(b"foobar"),
         }
 
-        response = self.client.post(self.endpoint, post_data, format="multipart")
-
+        audit_trail = generate_oas_component(
+            "drc",
+            "schemas/AuditTrail",
+            hoofdObject=document["url"],
+            resourceUrl=document["url"],
+            wijzigingen={
+                "oud": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:21.157+01:00",
+                    "author": "ONBEKEND",
+                    "versionLabel": "0.2",
+                },
+                "nieuw": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:39.293+01:00",
+                    "author": "John Doe",
+                    "versionLabel": "0.3",
+                },
+            },
+        )
+        audit_trail = factory(AuditTrailData, audit_trail)
+        with patch(
+            "zac.core.api.views.get_open_documenten",
+            return_value=[
+                DowcResponse(
+                    drc_url=document["url"], magic_url="", purpose="write", uuid=uuid4()
+                )
+            ],
+        ):
+            with patch(
+                "zac.core.api.views.fetch_document_audit_trail",
+                return_value=[audit_trail],
+            ):
+                response = self.client.post(
+                    self.endpoint, post_data, format="multipart"
+                )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @requests_mock.Mocker()
@@ -333,6 +370,27 @@ class ZaakDocumentPermissionTests(ClearCachesMixin, APITransactionTestCase):
             "vertrouwelijkheidaanduiding": "geheim",
             "zaak": f"{ZAKEN_ROOT}zaken/456",
         }
+        audit_trail = generate_oas_component(
+            "drc",
+            "schemas/AuditTrail",
+            hoofdObject=document["url"],
+            resourceUrl=document["url"],
+            wijzigingen={
+                "oud": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:21.157+01:00",
+                    "author": "ONBEKEND",
+                    "versionLabel": "0.2",
+                },
+                "nieuw": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:39.293+01:00",
+                    "author": "John Doe",
+                    "versionLabel": "0.3",
+                },
+            },
+        )
+        audit_trail = factory(AuditTrailData, audit_trail)
 
         with patch(
             "zac.core.api.serializers.get_documenten",
@@ -342,9 +400,24 @@ class ZaakDocumentPermissionTests(ClearCachesMixin, APITransactionTestCase):
                 "zac.core.api.views.update_document",
                 return_value=factory(Document, document),
             ):
-                response = self.client.patch(
-                    self.endpoint, post_data, format="multipart"
-                )
+                with patch(
+                    "zac.core.api.views.get_open_documenten",
+                    return_value=[
+                        DowcResponse(
+                            drc_url=document["url"],
+                            magic_url="",
+                            purpose="write",
+                            uuid=uuid4(),
+                        )
+                    ],
+                ):
+                    with patch(
+                        "zac.core.api.views.fetch_document_audit_trail",
+                        return_value=[audit_trail],
+                    ):
+                        response = self.client.patch(
+                            self.endpoint, post_data, format="multipart"
+                        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -471,7 +544,37 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "file": BytesIO(b"foobar"),
         }
 
-        response = self.client.post(self.endpoint, post_data, format="multipart")
+        audit_trail = generate_oas_component(
+            "drc",
+            "schemas/AuditTrail",
+            hoofdObject=document["url"],
+            resourceUrl=document["url"],
+            wijzigingen={
+                "oud": {},
+                "nieuw": {},
+            },
+            aanmaakdatum="2022-03-04T12:11:39.293+01:00",
+        )
+        audit_trail = factory(AuditTrailData, audit_trail)
+
+        with patch(
+            "zac.core.api.views.get_open_documenten",
+            return_value=[
+                DowcResponse(
+                    drc_url=document["url"],
+                    magic_url="",
+                    purpose="write",
+                    uuid=uuid4(),
+                )
+            ],
+        ):
+            with patch(
+                "zac.core.api.views.fetch_document_audit_trail",
+                return_value=[audit_trail],
+            ):
+                response = self.client.post(
+                    self.endpoint, post_data, format="multipart"
+                )
 
         called_urls = [req.url for req in m.request_history]
         # Check that informatieobjecttype url was called
@@ -488,7 +591,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "beschrijving": document["beschrijving"],
             "bestandsnaam": document["bestandsnaam"],
             "bestandsomvang": document["bestandsomvang"],
-            "currentUserIsEditing": None,
+            "currentUserIsEditing": False,
             "identificatie": document["identificatie"],
             "informatieobjecttype": {
                 "url": f"{CATALOGI_ROOT}informatieobjecttypen/d1b0512c-cdda-4779-b0bb-7ec1ee516e1b",
@@ -501,6 +604,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "versie": 1,
             "vertrouwelijkheidaanduiding": "Openbaar",
             "writeUrl": f'/api/dowc/{document["bronorganisatie"]}/{document["identificatie"]}/write',
+            "lastEditedDate": "2022-03-04T12:11:39.293000+01:00",
         }
         self.assertEqual(expected_data, data)
 
@@ -547,7 +651,37 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "url": DOCUMENT_URL,
         }
 
-        response = self.client.post(self.endpoint, post_data, format="multipart")
+        audit_trail = generate_oas_component(
+            "drc",
+            "schemas/AuditTrail",
+            hoofdObject=document["url"],
+            resourceUrl=document["url"],
+            wijzigingen={
+                "oud": {},
+                "nieuw": {},
+            },
+            aanmaakdatum="2022-03-04T12:11:39.293+01:00",
+        )
+        audit_trail = factory(AuditTrailData, audit_trail)
+
+        with patch(
+            "zac.core.api.views.get_open_documenten",
+            return_value=[
+                DowcResponse(
+                    drc_url=document["url"],
+                    magic_url="",
+                    purpose="write",
+                    uuid=uuid4(),
+                )
+            ],
+        ):
+            with patch(
+                "zac.core.api.views.fetch_document_audit_trail",
+                return_value=[audit_trail],
+            ):
+                response = self.client.post(
+                    self.endpoint, post_data, format="multipart"
+                )
 
         # Check that zaakinformatieobjecten url was called
         called_urls = [req.url for req in m.request_history]
@@ -561,7 +695,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "beschrijving": document["beschrijving"],
             "bestandsnaam": document["bestandsnaam"],
             "bestandsomvang": document["bestandsomvang"],
-            "currentUserIsEditing": None,
+            "currentUserIsEditing": False,
             "identificatie": document["identificatie"],
             "informatieobjecttype": {
                 "url": f"{CATALOGI_ROOT}informatieobjecttypen/d1b0512c-cdda-4779-b0bb-7ec1ee516e1b",
@@ -574,6 +708,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "versie": 1,
             "vertrouwelijkheidaanduiding": "Openbaar",
             "writeUrl": f'/api/dowc/{document["bronorganisatie"]}/{document["identificatie"]}/write',
+            "lastEditedDate": "2022-03-04T12:11:39.293000+01:00",
         }
         self.assertEqual(expected_data, data)
 
@@ -754,6 +889,27 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "zaak": f"{ZAKEN_ROOT}zaken/456",
             "bestandsnaam": "some-other-bestandsnaam.extension",
         }
+        audit_trail = generate_oas_component(
+            "drc",
+            "schemas/AuditTrail",
+            hoofdObject=document["url"],
+            resourceUrl=document["url"],
+            wijzigingen={
+                "oud": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:21.157+01:00",
+                    "author": "ONBEKEND",
+                    "versionLabel": "0.2",
+                },
+                "nieuw": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:39.293+01:00",
+                    "author": "John Doe",
+                    "versionLabel": "0.3",
+                },
+            },
+        )
+        audit_trail = factory(AuditTrailData, audit_trail)
         with patch(
             "zac.core.api.serializers.get_documenten",
             return_value=factory(
@@ -771,9 +927,24 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
                 "zac.core.api.serializers.get_documenten",
                 return_value=[[factory(Document, document)], []],
             ):
-                response = self.client.patch(
-                    self.endpoint, post_data, format="multipart"
-                )
+                with patch(
+                    "zac.core.api.views.get_open_documenten",
+                    return_value=[
+                        DowcResponse(
+                            drc_url=document["url"],
+                            magic_url="",
+                            purpose="write",
+                            uuid=uuid4(),
+                        )
+                    ],
+                ):
+                    with patch(
+                        "zac.core.api.views.fetch_document_audit_trail",
+                        return_value=[audit_trail],
+                    ):
+                        response = self.client.patch(
+                            self.endpoint, post_data, format="multipart"
+                        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
@@ -782,7 +953,7 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "beschrijving": document["beschrijving"],
             "bestandsnaam": document["bestandsnaam"],
             "bestandsomvang": None,
-            "currentUserIsEditing": None,
+            "currentUserIsEditing": False,
             "identificatie": document["identificatie"],
             "informatieobjecttype": {
                 "url": self.informatieobjecttype["url"],
@@ -795,5 +966,6 @@ class ZaakDocumentResponseTests(ClearCachesMixin, APITransactionTestCase):
             "versie": 1,
             "vertrouwelijkheidaanduiding": "Zaakvertrouwelijk",
             "writeUrl": f"/api/dowc/{document['bronorganisatie']}/{document['identificatie']}/write",
+            "lastEditedDate": "2022-03-04T12:11:39.293000+01:00",
         }
         self.assertEqual(data, expected_data)

--- a/backend/src/zac/core/api/tests/test_zaak_documents.py
+++ b/backend/src/zac/core/api/tests/test_zaak_documents.py
@@ -168,7 +168,7 @@ class ZaakDocumentsResponseTests(APITransactionTestCase):
                 "beschrijving": "some-beschrijving",
                 "bestandsnaam": "some-bestandsnaam",
                 "bestandsomvang": 10,
-                "currentUserIsEditing": True,
+                "currentUserIsEditing": False,
                 "identificatie": "DOC-2020-007",
                 "informatieobjecttype": {
                     "url": f"{CATALOGI_ROOT}informatieobjecttypen/d5d7285d-ce95-4f9e-a36f-181f1c642aa6",

--- a/backend/src/zac/core/api/tests/test_zaak_documents.py
+++ b/backend/src/zac/core/api/tests/test_zaak_documents.py
@@ -25,6 +25,7 @@ from zac.accounts.tests.factories import (
 from zac.contrib.dowc.constants import DocFileTypes
 from zac.contrib.dowc.data import DowcResponse
 from zac.contrib.kownsl.models import KownslConfig
+from zac.core.api.data import AuditTrailData
 from zac.core.permissions import zaken_download_documents, zaken_inzien
 from zac.core.tests.utils import ClearCachesMixin
 from zac.tests.utils import paginated_response
@@ -87,6 +88,27 @@ class ZaakDocumentsResponseTests(APITransactionTestCase):
         )
         doc_obj = factory(Document, document)
         doc_obj.informatieobjecttype = factory(InformatieObjectType, documenttype)
+        audit_trail = generate_oas_component(
+            "drc",
+            "schemas/AuditTrail",
+            hoofdObject=f"{DOCUMENTS_ROOT}enkelvoudiginformatieobjecten/0c47fe5e-4fe1-4781-8583-168e0730c9b6",
+            resourceUrl=f"{DOCUMENTS_ROOT}enkelvoudiginformatieobjecten/0c47fe5e-4fe1-4781-8583-168e0730c9b6",
+            wijzigingen={
+                "oud": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:21.157+01:00",
+                    "author": "ONBEKEND",
+                    "versionLabel": "0.2",
+                },
+                "nieuw": {
+                    "content": "",
+                    "modified": "2022-03-04T12:11:39.293+01:00",
+                    "author": "John Doe",
+                    "versionLabel": "0.3",
+                },
+            },
+        )
+        audit_trail = factory(AuditTrailData, audit_trail)
 
         zaaktype = generate_oas_component(
             "ztc",
@@ -132,7 +154,11 @@ class ZaakDocumentsResponseTests(APITransactionTestCase):
                         "zac.core.api.views.get_open_documenten",
                         return_value=[dowc],
                     ):
-                        response = self.client.get(self.endpoint)
+                        with patch(
+                            "zac.core.api.views.fetch_document_audit_trail",
+                            return_value=[audit_trail],
+                        ):
+                            response = self.client.get(self.endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -169,6 +195,7 @@ class ZaakDocumentsResponseTests(APITransactionTestCase):
                         "purpose": DocFileTypes.write,
                     },
                 ),
+                "lastEditedDate": "2022-03-04T12:11:39.293000+01:00",
             }
         ]
         self.assertEqual(response_data, expected)
@@ -272,6 +299,14 @@ class ZaakDocumentsPermissionTests(ClearCachesMixin, APITestCase):
             vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.beperkt_openbaar,
         )
         cls.doc_obj = factory(Document, cls.document)
+        audit_trail = generate_oas_component(
+            "drc",
+            "schemas/AuditTrail",
+            resourceUrl=f"{DOCUMENTS_ROOT}enkelvoudiginformatieobjecten/e3f5c6d2-0e49-4293-8428-26139f630951",
+            hoofdObject=f"{DOCUMENTS_ROOT}enkelvoudiginformatieobjecten/e3f5c6d2-0e49-4293-8428-26139f630951",
+            wijzigingen={"nieuw": {}, "oud": {}},
+        )
+        cls.audit_trail = [factory(AuditTrailData, audit_trail)]
 
         cls.dowc = DowcResponse(
             drc_url=cls.doc_obj.url,
@@ -427,5 +462,9 @@ class ZaakDocumentsPermissionTests(ClearCachesMixin, APITestCase):
         with patch(
             "zac.core.api.views.get_documenten", return_value=([self.doc_obj], [])
         ):
-            response = self.client.get(self.endpoint)
+            with patch(
+                "zac.core.api.views.fetch_document_audit_trail",
+                return_value=self.audit_trail,
+            ):
+                response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -1,8 +1,8 @@
 import base64
 import logging
-from datetime import date
+from datetime import date, datetime
 from itertools import groupby
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
@@ -29,12 +29,14 @@ from rest_framework.response import Response
 from zds_client.client import ClientError
 from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
+from zgw_consumers.api_models.documenten import Document
 from zgw_consumers.concurrent import parallel
 from zgw_consumers.models import Service
 
 from zac.accounts.models import User, UserAtomicPermission
 from zac.contrib.brp.api import fetch_extrainfo_np
 from zac.contrib.dowc.api import get_open_documenten
+from zac.contrib.dowc.data import DowcResponse
 from zac.core.services import (
     fetch_objecttype_version,
     fetch_objecttypes,
@@ -588,7 +590,9 @@ class ListZaakDocumentsView(GetZaakMixin, views.APIView):
             at = sorted(at, key=lambda obj: obj.aanmaakdatum, reverse=True)
             bumped_versions = [edit for edit in at if edit.was_bumped] or at
             bumped_version = bumped_versions[0]
-            editing_history[bumped_version.resource_url] = bumped_version.modified
+            editing_history[
+                bumped_version.resource_url
+            ] = bumped_version.last_edited_date
 
         serializer = self.serializer_class(
             instance=resolved_documenten,
@@ -640,6 +644,19 @@ class ZaakDocumentView(views.APIView):
         document_data = {**document_data, **validated_data}
         return document_data
 
+    def get_document_audit_trail(self, document: Document) -> Dict[str, datetime]:
+        audittrail = fetch_document_audit_trail(document.url)
+        audittrail = sorted(audittrail, key=lambda obj: obj.aanmaakdatum, reverse=True)
+        bumped_versions = [edit for edit in audittrail if edit.was_bumped] or audittrail
+        editing_history = {
+            bumped_versions[0].resource_url: bumped_versions[0].last_edited_date
+        }
+        return editing_history
+
+    def get_open_documenten(self) -> List[Optional[DowcResponse]]:
+        referer = self.request.headers.get("referer", "")
+        return get_open_documenten(self.request.user, referer)
+
     @extend_schema(
         summary=_("Partially update ZAAK document."),
         responses=GetZaakDocumentSerializer,
@@ -666,7 +683,14 @@ class ZaakDocumentView(views.APIView):
         document.informatieobjecttype = get_informatieobjecttype(
             document.informatieobjecttype
         )
-        serializer = GetZaakDocumentSerializer(instance=document)
+
+        serializer = GetZaakDocumentSerializer(
+            instance=document,
+            context={
+                "open_documenten": self.get_open_documenten(),
+                "editing_history": self.get_document_audit_trail(document),
+            },
+        )
         return Response(serializer.data)
 
     @extend_schema(
@@ -698,7 +722,13 @@ class ZaakDocumentView(views.APIView):
         document.informatieobjecttype = get_informatieobjecttype(
             document.informatieobjecttype
         )
-        serializer = GetZaakDocumentSerializer(instance=document)
+        serializer = GetZaakDocumentSerializer(
+            instance=document,
+            context={
+                "open_documenten": self.get_open_documenten(),
+                "editing_history": self.get_document_audit_trail(document),
+            },
+        )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 

--- a/backend/src/zac/core/services.py
+++ b/backend/src/zac/core/services.py
@@ -41,6 +41,7 @@ from zac.utils.decorators import cache as cache_result
 from zac.utils.exceptions import ServiceConfigError
 from zgw.models import Zaak
 
+from .api.data import AuditTrailData
 from .api.utils import convert_eigenschap_spec_to_json_schema
 from .cache import invalidate_document_cache, invalidate_zaak_cache
 from .models import CoreConfig
@@ -1143,6 +1144,15 @@ def relate_document_to_zaak(document_url: str, zaak_url: str) -> Dict[str, str]:
         },
     )
     return response
+
+
+def fetch_document_audit_trail(document_url: str) -> List[AuditTrailData]:
+    drc_client = _client_from_url(document_url)
+    doc_uuid = furl(document_url).path.segments[-1]
+    audit_trail = drc_client.list(
+        "audittrail", enkelvoudiginformatieobject_uuid=doc_uuid
+    )
+    return factory(AuditTrailData, audit_trail)
 
 
 ###################################################


### PR DESCRIPTION
Takes the last edit from the audit trail of the document and includes it as lastEditedDate in the GET response.

Related to https://github.com/GemeenteUtrecht/ZGW/issues/1216