### PR TITLE
:bug: Fix patching a zaakeigenschap

### DIFF
--- a/backend/src/zac/core/api/serializers.py
+++ b/backend/src/zac/core/api/serializers.py
@@ -550,19 +550,19 @@ class EigenschapSerializer(APIModelSerializer):
 
 
 class CharValueSerializer(APIModelSerializer):
-    value = serializers.CharField(
+    waarde = serializers.CharField(
         label=_("EIGENSCHAP value"),
         source="get_waarde",
     )
 
     class Meta:
         model = ZaakEigenschap
-        fields = ("value",)
+        fields = ("waarde",)
 
 
 class NumberValueSerializer(APIModelSerializer):
     # TODO: Ideally this should be dynamic based on eigenschapsspecificatie
-    value = serializers.DecimalField(
+    waarde = serializers.DecimalField(
         label=_("EIGENSCHAP value"),
         source="get_waarde",
         max_digits=100,
@@ -572,29 +572,29 @@ class NumberValueSerializer(APIModelSerializer):
 
     class Meta:
         model = ZaakEigenschap
-        fields = ("value",)
+        fields = ("waarde",)
 
 
 class DateValueSerializer(APIModelSerializer):
-    value = serializers.DateField(
+    waarde = serializers.DateField(
         label=_("EIGENSCHAP value"),
         source="get_waarde",
     )
 
     class Meta:
         model = ZaakEigenschap
-        fields = ("value",)
+        fields = ("waarde",)
 
 
 class DateTimeValueSerializer(APIModelSerializer):
-    value = serializers.DateTimeField(
+    waarde = serializers.DateTimeField(
         label=_("EIGENSCHAP value"),
         source="get_waarde",
     )
 
     class Meta:
         model = ZaakEigenschap
-        fields = ("value",)
+        fields = ("waarde",)
 
 
 class ZaakEigenschapSerializer(PolymorphicSerializer, APIModelSerializer):
@@ -634,12 +634,20 @@ class CreateZaakEigenschapSerializer(serializers.Serializer):
             "Name of EIGENSCHAP. Must match EIGENSCHAP name as defined in CATALOGI API."
         )
     )
-    value = serializers.CharField(
+    waarde = serializers.CharField(
         help_text=_(
             "Value of ZAAKEIGENSCHAP. Must be able to be formatted as defined by the EIGENSCHAP spec."
         )
     )
     zaak_url = serializers.URLField(help_text=_("URL-reference to ZAAK."))
+
+
+class UpdateZaakEigenschapWaardeSerializer(serializers.Serializer):
+    waarde = serializers.CharField(
+        help_text=_(
+            "Value of ZAAKEIGENSCHAP. Must be formatted as defined by the EIGENSCHAP spec."
+        )
+    )
 
 
 class RelatedZaakDetailSerializer(ZaakDetailSerializer):

--- a/backend/src/zac/core/api/tests/test_zaak_eigenschappen.py
+++ b/backend/src/zac/core/api/tests/test_zaak_eigenschappen.py
@@ -130,7 +130,7 @@ class ZaakEigenschappenResponseTests(ClearCachesMixin, APITestCase):
             {
                 "url": eigenschap["url"],
                 "formaat": "tekst",
-                "value": "bar",
+                "waarde": "bar",
                 "eigenschap": {
                     "url": self.eigenschap["url"],
                     "naam": "some-property",

--- a/backend/src/zac/core/api/tests/test_zaak_eigenschappen_detail.py
+++ b/backend/src/zac/core/api/tests/test_zaak_eigenschappen_detail.py
@@ -688,7 +688,6 @@ class ZaakPropertiesDetailPermissionTests(ClearCachesMixin, APITestCase):
         mock_resource_get(m, self.zaaktype)
         mock_resource_get(m, self.eigenschap)
         mock_resource_get(m, self.zaak_eigenschap)
-        m.patch(ZAAK_EIGENSCHAP_URL, json=self.zaak_eigenschap)
 
         user = UserFactory.create()
         BlueprintPermissionFactory.create(
@@ -714,7 +713,15 @@ class ZaakPropertiesDetailPermissionTests(ClearCachesMixin, APITestCase):
         mock_resource_get(m, self.zaaktype)
         mock_resource_get(m, self.eigenschap)
         mock_resource_get(m, self.zaak_eigenschap)
-        m.patch(ZAAK_EIGENSCHAP_URL, json=self.zaak_eigenschap)
+        eigenschappen_url = furl(CATALOGI_ROOT)
+        eigenschappen_url.path.segments += ["eigenschappen"]
+        eigenschappen_url.path.normalize()
+        eigenschappen_url.query = {"zaaktype": self.zaaktype["url"]}
+        m.get(eigenschappen_url.url, json=paginated_response([self.eigenschap]))
+        m.delete(ZAAK_EIGENSCHAP_URL, status_code=204)
+        m.post(
+            f"{ZAAK_URL}/zaakeigenschappen", json=self.zaak_eigenschap, status_code=201
+        )
 
         user = UserFactory.create()
         BlueprintPermissionFactory.create(

--- a/backend/src/zac/core/api/tests/test_zaak_eigenschappen_detail.py
+++ b/backend/src/zac/core/api/tests/test_zaak_eigenschappen_detail.py
@@ -71,238 +71,7 @@ class ZaakEigenschappenDetailResponseTests(ClearCachesMixin, APITestCase):
 
         # ensure that we have a user with all permissions
         self.client.force_authenticate(user=self.user)
-
-    def test_patch_zaak_eigenschap_tekst(self, m):
-        eigenschap = generate_oas_component(
-            "ztc",
-            "schemas/Eigenschap",
-            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
-            zaaktype=self.zaaktype["url"],
-            naam="some-property",
-            specificatie={
-                "groep": "dummy",
-                "formaat": "tekst",
-                "lengte": "3",
-                "kardinaliteit": "1",
-                "waardenverzameling": [],
-            },
-        )
-        zaak_eigenschap = generate_oas_component(
-            "zrc",
-            "schemas/ZaakEigenschap",
-            url=ZAAK_EIGENSCHAP_URL,
-            zaak=ZAAK_URL,
-            eigenschap=eigenschap["url"],
-            naam=eigenschap["naam"],
-            waarde="old",
-        )
-        zaak_eigenschap_new = zaak_eigenschap.copy()
-        zaak_eigenschap_new.update({"waarde": "new"})
-
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
-        mock_resource_get(m, self.zaak)
-        mock_resource_get(m, self.zaaktype)
-        mock_resource_get(m, zaak_eigenschap)
-        mock_resource_get(m, eigenschap)
-        m.patch(ZAAK_EIGENSCHAP_URL, json=zaak_eigenschap_new)
-
-        response = self.client.patch(self.endpoint, data={"value": "new"})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response_data = response.json()
-        self.assertEqual(
-            response_data,
-            {
-                "url": ZAAK_EIGENSCHAP_URL,
-                "formaat": "tekst",
-                "value": "new",
-                "eigenschap": {
-                    "url": eigenschap["url"],
-                    "naam": "some-property",
-                    "toelichting": eigenschap["toelichting"],
-                    "specificatie": eigenschap["specificatie"],
-                },
-            },
-        )
-
-        last_request = m.request_history[-1]
-        self.assertEqual(last_request.method, "PATCH")
-        self.assertEqual(last_request.url, ZAAK_EIGENSCHAP_URL)
-        self.assertEqual(last_request.json(), {"waarde": "new"})
-
-    def test_patch_zaak_eigenschap_getal(self, m):
-        eigenschap = generate_oas_component(
-            "ztc",
-            "schemas/Eigenschap",
-            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
-            zaaktype=self.zaaktype["url"],
-            naam="some-property",
-            specificatie={
-                "groep": "dummy",
-                "formaat": "getal",
-                "lengte": "2",
-                "kardinaliteit": "1",
-                "waardenverzameling": [],
-            },
-        )
-        zaak_eigenschap = generate_oas_component(
-            "zrc",
-            "schemas/ZaakEigenschap",
-            url=ZAAK_EIGENSCHAP_URL,
-            zaak=ZAAK_URL,
-            eigenschap=eigenschap["url"],
-            naam=eigenschap["naam"],
-            waarde="10",
-        )
-        zaak_eigenschap_new = zaak_eigenschap.copy()
-        zaak_eigenschap_new.update({"waarde": "20"})
-
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
-        mock_resource_get(m, self.zaak)
-        mock_resource_get(m, self.zaaktype)
-        mock_resource_get(m, zaak_eigenschap)
-        mock_resource_get(m, eigenschap)
-        m.patch(ZAAK_EIGENSCHAP_URL, json=zaak_eigenschap_new)
-
-        response = self.client.patch(self.endpoint, data={"value": 20})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response_data = response.json()
-        self.assertEqual(
-            response_data,
-            {
-                "url": ZAAK_EIGENSCHAP_URL,
-                "formaat": "getal",
-                "value": "20.00",
-                "eigenschap": {
-                    "url": eigenschap["url"],
-                    "naam": "some-property",
-                    "toelichting": eigenschap["toelichting"],
-                    "specificatie": eigenschap["specificatie"],
-                },
-            },
-        )
-
-        last_request = m.request_history[-1]
-        self.assertEqual(last_request.method, "PATCH")
-        self.assertEqual(last_request.url, ZAAK_EIGENSCHAP_URL)
-        self.assertEqual(last_request.json(), {"waarde": "20"})
-
-    def test_patch_zaak_eigenschap_datum(self, m):
-        eigenschap = generate_oas_component(
-            "ztc",
-            "schemas/Eigenschap",
-            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
-            zaaktype=self.zaaktype["url"],
-            naam="some-property",
-            specificatie={
-                "groep": "dummy",
-                "formaat": "datum",
-                "lengte": "2",
-                "kardinaliteit": "1",
-                "waardenverzameling": [],
-            },
-        )
-        zaak_eigenschap = generate_oas_component(
-            "zrc",
-            "schemas/ZaakEigenschap",
-            url=ZAAK_EIGENSCHAP_URL,
-            zaak=ZAAK_URL,
-            eigenschap=eigenschap["url"],
-            naam=eigenschap["naam"],
-            waarde="2020-01-01",
-        )
-        zaak_eigenschap_new = zaak_eigenschap.copy()
-        zaak_eigenschap_new.update({"waarde": "2020-02-02"})
-
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
-        mock_resource_get(m, self.zaak)
-        mock_resource_get(m, self.zaaktype)
-        mock_resource_get(m, zaak_eigenschap)
-        mock_resource_get(m, eigenschap)
-        m.patch(ZAAK_EIGENSCHAP_URL, json=zaak_eigenschap_new)
-
-        response = self.client.patch(self.endpoint, data={"value": "2020-02-02"})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response_data = response.json()
-        self.assertEqual(
-            response_data,
-            {
-                "url": ZAAK_EIGENSCHAP_URL,
-                "formaat": "datum",
-                "value": "2020-02-02",
-                "eigenschap": {
-                    "url": eigenschap["url"],
-                    "naam": "some-property",
-                    "toelichting": eigenschap["toelichting"],
-                    "specificatie": eigenschap["specificatie"],
-                },
-            },
-        )
-
-        last_request = m.request_history[-1]
-        self.assertEqual(last_request.method, "PATCH")
-        self.assertEqual(last_request.url, ZAAK_EIGENSCHAP_URL)
-        self.assertEqual(last_request.json(), {"waarde": "2020-02-02"})
-
-    def test_patch_zaak_eigenschap_not_found(self, m):
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        m.get(ZAAK_EIGENSCHAP_URL, text="Not Found", status_code=404)
-
-        response = self.client.patch(self.endpoint, data={"value": "new"})
-
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_patch_zaak_eigenschap_incorrect_format(self, m):
-        eigenschap = generate_oas_component(
-            "ztc",
-            "schemas/Eigenschap",
-            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
-            zaaktype=self.zaaktype["url"],
-            naam="some-property",
-            specificatie={
-                "groep": "dummy",
-                "formaat": "getal",
-                "lengte": "2",
-                "kardinaliteit": "1",
-                "waardenverzameling": [],
-            },
-        )
-        zaak_eigenschap = generate_oas_component(
-            "zrc",
-            "schemas/ZaakEigenschap",
-            url=ZAAK_EIGENSCHAP_URL,
-            zaak=ZAAK_URL,
-            eigenschap=eigenschap["url"],
-            naam=eigenschap["naam"],
-            waarde="10",
-        )
-
-        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
-        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
-        mock_resource_get(m, self.zaak)
-        mock_resource_get(m, zaak_eigenschap)
-        mock_resource_get(m, eigenschap)
-
-        response = self.client.patch(self.endpoint, data={"value": "new"})
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue("value" in response.json())
-
-    def test_patch_without_url(self, m):
-        endpoint = reverse("zaak-properties-detail")
-
-        response = self.client.patch(endpoint, data={"value": "new"})
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue("url" in response.json())
+        self.maxDiff = None
 
     def test_create_zaak_eigenschap(self, m):
         eigenschap = generate_oas_component(
@@ -340,17 +109,13 @@ class ZaakEigenschappenDetailResponseTests(ClearCachesMixin, APITestCase):
         eigenschappen_url.query = {"zaaktype": self.zaaktype["url"]}
         m.get(eigenschappen_url.url, json=paginated_response([eigenschap]))
 
-        zei_url = furl(self.zaak["url"])
-        zei_url.path.segments += ["zaakeigenschappen"]
-        zei_url.path.normalize()
-
-        m.post(zei_url.url, json=zaak_eigenschap, status_code=201)
+        m.post(f"{ZAAK_URL}/zaakeigenschappen", json=zaak_eigenschap, status_code=201)
         response = self.client.post(
             self.endpoint,
             data={
                 "zaak_url": ZAAK_URL,
                 "naam": zaak_eigenschap["naam"],
-                "value": zaak_eigenschap["waarde"],
+                "waarde": zaak_eigenschap["waarde"],
             },
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -371,7 +136,7 @@ class ZaakEigenschappenDetailResponseTests(ClearCachesMixin, APITestCase):
                         "waardenverzameling": [],
                     },
                 },
-                "value": "10.00",
+                "waarde": "10.00",
             },
         )
 
@@ -407,7 +172,7 @@ class ZaakEigenschappenDetailResponseTests(ClearCachesMixin, APITestCase):
             data={
                 "zaak_url": ZAAK_URL,
                 "naam": "some-other-property",
-                "value": "10",
+                "waarde": "10",
             },
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -474,6 +239,316 @@ class ZaakEigenschappenDetailResponseTests(ClearCachesMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertTrue("url" in response.json())
 
+    def test_patch_zaak_eigenschap_tekst(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        eigenschap = generate_oas_component(
+            "ztc",
+            "schemas/Eigenschap",
+            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            zaaktype=self.zaaktype["url"],
+            naam="some-property",
+            specificatie={
+                "groep": "dummy",
+                "formaat": "tekst",
+                "lengte": "3",
+                "kardinaliteit": "1",
+                "waardenverzameling": [],
+            },
+        )
+        old_zaak_eigenschap = generate_oas_component(
+            "zrc",
+            "schemas/ZaakEigenschap",
+            url=ZAAK_EIGENSCHAP_URL,
+            zaak=ZAAK_URL,
+            eigenschap=eigenschap["url"],
+            naam=eigenschap["naam"],
+            waarde="old",
+        )
+        new_zaak_eigenschap = generate_oas_component(
+            "zrc",
+            "schemas/ZaakEigenschap",
+            url=f"{ZAAK_URL}/zaakeigenschappen/829ba774-ffd4-4727-8aa3-bf91db611f76",
+            zaak=ZAAK_URL,
+            eigenschap=eigenschap["url"],
+            naam=eigenschap["naam"],
+            waarde="new",
+        )
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, old_zaak_eigenschap)
+        mock_resource_get(m, new_zaak_eigenschap)
+        mock_resource_get(m, eigenschap)
+        eigenschappen_url = furl(CATALOGI_ROOT)
+        eigenschappen_url.path.segments += ["eigenschappen"]
+        eigenschappen_url.path.normalize()
+        eigenschappen_url.query = {"zaaktype": self.zaaktype["url"]}
+        m.get(eigenschappen_url.url, json=paginated_response([eigenschap]))
+
+        m.delete(ZAAK_EIGENSCHAP_URL, status_code=204)
+        m.post(
+            f"{ZAAK_URL}/zaakeigenschappen", json=new_zaak_eigenschap, status_code=201
+        )
+
+        response = self.client.patch(self.endpoint, data={"waarde": "new"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(
+            response_data,
+            {
+                "url": f"{ZAAK_URL}/zaakeigenschappen/829ba774-ffd4-4727-8aa3-bf91db611f76",
+                "formaat": "tekst",
+                "waarde": "new",
+                "eigenschap": {
+                    "url": eigenschap["url"],
+                    "naam": "some-property",
+                    "toelichting": eigenschap["toelichting"],
+                    "specificatie": eigenschap["specificatie"],
+                },
+            },
+        )
+
+        self.assertEqual(m.request_history[-2].method, "POST")
+        self.assertEqual(m.request_history[-2].url, f"{ZAAK_URL}/zaakeigenschappen")
+
+        self.assertEqual(
+            m.request_history[-2].json(),
+            {
+                "zaak": old_zaak_eigenschap["zaak"],
+                "eigenschap": old_zaak_eigenschap["eigenschap"],
+                "waarde": "new",
+            },
+        )
+        self.assertEqual(m.request_history[-1].method, "DELETE")
+        self.assertEqual(m.request_history[-1].url, ZAAK_EIGENSCHAP_URL)
+
+    def test_patch_zaak_eigenschap_getal(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        eigenschap = generate_oas_component(
+            "ztc",
+            "schemas/Eigenschap",
+            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            zaaktype=self.zaaktype["url"],
+            naam="some-property",
+            specificatie={
+                "groep": "dummy",
+                "formaat": "getal",
+                "lengte": "2",
+                "kardinaliteit": "1",
+                "waardenverzameling": [],
+            },
+        )
+        old_zaak_eigenschap = generate_oas_component(
+            "zrc",
+            "schemas/ZaakEigenschap",
+            url=ZAAK_EIGENSCHAP_URL,
+            zaak=ZAAK_URL,
+            eigenschap=eigenschap["url"],
+            naam=eigenschap["naam"],
+            waarde="10",
+        )
+        new_zaak_eigenschap = generate_oas_component(
+            "zrc",
+            "schemas/ZaakEigenschap",
+            url=f"{ZAAK_URL}/zaakeigenschappen/829ba774-ffd4-4727-8aa3-bf91db611f76",
+            zaak=ZAAK_URL,
+            eigenschap=eigenschap["url"],
+            naam=eigenschap["naam"],
+            waarde="20",
+        )
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, old_zaak_eigenschap)
+        mock_resource_get(m, new_zaak_eigenschap)
+        mock_resource_get(m, eigenschap)
+        eigenschappen_url = furl(CATALOGI_ROOT)
+        eigenschappen_url.path.segments += ["eigenschappen"]
+        eigenschappen_url.path.normalize()
+        eigenschappen_url.query = {"zaaktype": self.zaaktype["url"]}
+        m.get(eigenschappen_url.url, json=paginated_response([eigenschap]))
+
+        m.delete(ZAAK_EIGENSCHAP_URL, status_code=204)
+        m.post(
+            f"{ZAAK_URL}/zaakeigenschappen", json=new_zaak_eigenschap, status_code=201
+        )
+
+        response = self.client.patch(self.endpoint, data={"waarde": 20})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data,
+            {
+                "url": f"{ZAAK_URL}/zaakeigenschappen/829ba774-ffd4-4727-8aa3-bf91db611f76",
+                "formaat": "getal",
+                "waarde": "20.00",
+                "eigenschap": {
+                    "url": eigenschap["url"],
+                    "naam": "some-property",
+                    "toelichting": eigenschap["toelichting"],
+                    "specificatie": eigenschap["specificatie"],
+                },
+            },
+        )
+
+        self.assertEqual(m.request_history[-2].method, "POST")
+        self.assertEqual(m.request_history[-2].url, f"{ZAAK_URL}/zaakeigenschappen")
+
+        self.assertEqual(
+            m.request_history[-2].json(),
+            {
+                "zaak": old_zaak_eigenschap["zaak"],
+                "eigenschap": old_zaak_eigenschap["eigenschap"],
+                "waarde": 20,
+            },
+        )
+        self.assertEqual(m.request_history[-1].method, "DELETE")
+        self.assertEqual(m.request_history[-1].url, ZAAK_EIGENSCHAP_URL)
+
+    def test_patch_zaak_eigenschap_datum(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        eigenschap = generate_oas_component(
+            "ztc",
+            "schemas/Eigenschap",
+            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            zaaktype=self.zaaktype["url"],
+            naam="some-property",
+            specificatie={
+                "groep": "dummy",
+                "formaat": "datum",
+                "lengte": "2",
+                "kardinaliteit": "1",
+                "waardenverzameling": [],
+            },
+        )
+        old_zaak_eigenschap = generate_oas_component(
+            "zrc",
+            "schemas/ZaakEigenschap",
+            url=ZAAK_EIGENSCHAP_URL,
+            zaak=ZAAK_URL,
+            eigenschap=eigenschap["url"],
+            naam=eigenschap["naam"],
+            waarde="2020-01-01",
+        )
+        new_zaak_eigenschap = generate_oas_component(
+            "zrc",
+            "schemas/ZaakEigenschap",
+            url=f"{ZAAK_URL}/zaakeigenschappen/829ba774-ffd4-4727-8aa3-bf91db611f76",
+            zaak=ZAAK_URL,
+            eigenschap=eigenschap["url"],
+            naam=eigenschap["naam"],
+            waarde="2020-02-02",
+        )
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, old_zaak_eigenschap)
+        mock_resource_get(m, new_zaak_eigenschap)
+        mock_resource_get(m, eigenschap)
+        eigenschappen_url = furl(CATALOGI_ROOT)
+        eigenschappen_url.path.segments += ["eigenschappen"]
+        eigenschappen_url.path.normalize()
+        eigenschappen_url.query = {"zaaktype": self.zaaktype["url"]}
+        m.get(eigenschappen_url.url, json=paginated_response([eigenschap]))
+
+        m.delete(ZAAK_EIGENSCHAP_URL, status_code=204)
+        m.post(
+            f"{ZAAK_URL}/zaakeigenschappen", json=new_zaak_eigenschap, status_code=201
+        )
+
+        response = self.client.patch(self.endpoint, data={"waarde": "2020-02-02"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data,
+            {
+                "url": f"{ZAAK_URL}/zaakeigenschappen/829ba774-ffd4-4727-8aa3-bf91db611f76",
+                "formaat": "datum",
+                "waarde": "2020-02-02",
+                "eigenschap": {
+                    "url": eigenschap["url"],
+                    "naam": "some-property",
+                    "toelichting": eigenschap["toelichting"],
+                    "specificatie": eigenschap["specificatie"],
+                },
+            },
+        )
+
+        self.assertEqual(m.request_history[-2].method, "POST")
+        self.assertEqual(m.request_history[-2].url, f"{ZAAK_URL}/zaakeigenschappen")
+
+        self.assertEqual(
+            m.request_history[-2].json(),
+            {
+                "zaak": old_zaak_eigenschap["zaak"],
+                "eigenschap": old_zaak_eigenschap["eigenschap"],
+                "waarde": "2020-02-02",
+            },
+        )
+        self.assertEqual(m.request_history[-1].method, "DELETE")
+        self.assertEqual(m.request_history[-1].url, ZAAK_EIGENSCHAP_URL)
+
+    def test_patch_zaak_eigenschap_not_found(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        m.get(ZAAK_EIGENSCHAP_URL, text="Not Found", status_code=404)
+
+        response = self.client.patch(self.endpoint, data={"waarde": "new"})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_patch_zaak_eigenschap_incorrect_format(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        eigenschap = generate_oas_component(
+            "ztc",
+            "schemas/Eigenschap",
+            url=f"{CATALOGI_ROOT}eigenschappen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            zaaktype=self.zaaktype["url"],
+            naam="some-property",
+            specificatie={
+                "groep": "dummy",
+                "formaat": "getal",
+                "lengte": "2",
+                "kardinaliteit": "1",
+                "waardenverzameling": [],
+            },
+        )
+        zaak_eigenschap = generate_oas_component(
+            "zrc",
+            "schemas/ZaakEigenschap",
+            url=ZAAK_EIGENSCHAP_URL,
+            zaak=ZAAK_URL,
+            eigenschap=eigenschap["url"],
+            naam=eigenschap["naam"],
+            waarde="10",
+        )
+
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, zaak_eigenschap)
+        mock_resource_get(m, eigenschap)
+
+        response = self.client.patch(self.endpoint, data={"waarde": "new"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue("waarde" in response.json())
+
+    def test_patch_without_url(self, m):
+        endpoint = reverse("zaak-properties-detail")
+
+        response = self.client.patch(endpoint, data={"waarde": "new"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue("url" in response.json())
+
 
 class ZaakPropertiesDetailPermissionTests(ClearCachesMixin, APITestCase):
     @classmethod
@@ -529,7 +604,7 @@ class ZaakPropertiesDetailPermissionTests(ClearCachesMixin, APITestCase):
             naam=cls.eigenschap["naam"],
             waarde="old",
         )
-        cls.data = {"value": "new"}
+        cls.data = {"waarde": "new"}
 
         cls.endpoint = f"{reverse('zaak-properties-detail')}?url={ZAAK_EIGENSCHAP_URL}"
 
@@ -579,7 +654,15 @@ class ZaakPropertiesDetailPermissionTests(ClearCachesMixin, APITestCase):
         mock_resource_get(m, self.zaaktype)
         mock_resource_get(m, self.eigenschap)
         mock_resource_get(m, self.zaak_eigenschap)
-        m.patch(ZAAK_EIGENSCHAP_URL, json=self.zaak_eigenschap)
+        eigenschappen_url = furl(CATALOGI_ROOT)
+        eigenschappen_url.path.segments += ["eigenschappen"]
+        eigenschappen_url.path.normalize()
+        eigenschappen_url.query = {"zaaktype": self.zaaktype["url"]}
+        m.get(eigenschappen_url.url, json=paginated_response([self.eigenschap]))
+        m.delete(ZAAK_EIGENSCHAP_URL, status_code=204)
+        m.post(
+            f"{ZAAK_URL}/zaakeigenschappen", json=self.zaak_eigenschap, status_code=201
+        )
 
         user = UserFactory.create()
         BlueprintPermissionFactory.create(

--- a/backend/src/zac/core/services.py
+++ b/backend/src/zac/core/services.py
@@ -621,7 +621,7 @@ def fetch_zaak_eigenschap(zaak_eigenschap_url: str) -> ZaakEigenschap:
 
 
 def create_zaak_eigenschap(
-    user: Optional[User] = None, zaak_url: str = "", naam: str = "", value: str = ""
+    user: Optional[User] = None, zaak_url: str = "", naam: str = "", waarde: str = ""
 ) -> Optional[ZaakEigenschap]:
     zaak = get_zaak(zaak_url=zaak_url)
     zaaktype = get_zaaktype(zaak.zaaktype, user=user)
@@ -648,21 +648,24 @@ def create_zaak_eigenschap(
         {
             "zaak": zaak_url,
             "eigenschap": eigenschap_url,
-            "waarde": value,
+            "waarde": waarde,
         },
         zaak_uuid=zaak_url.split("/")[-1],
     )
     return factory(ZaakEigenschap, zaak_eigenschap)
 
 
-def update_zaak_eigenschap(zaak_eigenschap_url: str, data: dict) -> ZaakEigenschap:
-    client = _client_from_url(zaak_eigenschap_url)
-    zaak_eigenschap = client.partial_update(
-        "zaakeigenschap", data=data, url=zaak_eigenschap_url
+def update_zaak_eigenschap(
+    zaak_eigenschap: ZaakEigenschap, data: dict, user: Optional[User] = None
+) -> ZaakEigenschap:
+    zei = create_zaak_eigenschap(
+        user=user,
+        zaak_url=zaak_eigenschap.zaak,
+        naam=zaak_eigenschap.naam,
+        waarde=data["waarde"],
     )
-    zaak_eigenschap = factory(ZaakEigenschap, zaak_eigenschap)
-    zaak_eigenschap.eigenschap = get_eigenschap(zaak_eigenschap.eigenschap)
-    return zaak_eigenschap
+    delete_zaak_eigenschap(zaak_eigenschap.url)
+    return zei
 
 
 def delete_zaak_eigenschap(zaak_eigenschap_url: str):

--- a/backend/src/zac/core/services.py
+++ b/backend/src/zac/core/services.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 import requests
 from furl import furl
 from requests.models import Response
+from zds_client import ClientError
 from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.besluiten import Besluit, BesluitDocument
 from zgw_consumers.api_models.catalogi import (
@@ -664,7 +665,15 @@ def update_zaak_eigenschap(
         naam=zaak_eigenschap.naam,
         waarde=data["waarde"],
     )
-    delete_zaak_eigenschap(zaak_eigenschap.url)
+    try:
+        delete_zaak_eigenschap(zaak_eigenschap.url)
+    except ClientError as exc:
+        logger.info(
+            "Could not delete zaakeigenschap {zaakeigenschap}.".format(
+                zaakeigenschap=zaak_eigenschap.url
+            ),
+            exc_info=True,
+        )
     return zei
 
 

--- a/frontend/zac-ui/libs/features/reports/src/lib/features-reports.component.ts
+++ b/frontend/zac-ui/libs/features/reports/src/lib/features-reports.component.ts
@@ -50,7 +50,7 @@ export class FeaturesReportsComponent implements OnInit {
   formatReportTable(data: ReportCase[]) {
     return data.map((element) => {
       const url = `/ui/zaken/${element.bronorganisatie}/${element.identificatie}`;
-      const eigenschappen = element.eigenschappen?.map(e => `${e.eigenschap.naam}: ${e.value}`).join('\n')
+      const eigenschappen = element.eigenschappen?.map(e => `${e.eigenschap.naam}: ${e.waarde}`).join('\n')
       const cellData: RowData = {
         cellData: {
           zaaknummer: {

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/informatie/informatie.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/informatie/informatie.component.ts
@@ -326,7 +326,7 @@ export class InformatieComponent implements OnInit, OnChanges {
       this.zaakService.updateCaseProperty(property).subscribe(
         () => {},
         this.reportError.bind(this),
-        () => this.isPropertyAPILoading--,
+        () => this.isPropertyAPILoading = 0,
       );
 
       return acc + 1;

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/informatie/informatie.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/informatie/informatie.component.ts
@@ -139,7 +139,7 @@ export class InformatieComponent implements OnInit, OnChanges {
   get propertyFieldConfigurations(): FieldConfiguration[] {
     return this.zaaktypeEigenschappen.map((zaaktypeEigenschap: ZaaktypeEigenschap): FieldConfiguration => {
       const property = this.properties.find((p: EigenschapWaarde) => p.eigenschap.naam === zaaktypeEigenschap.name)
-      const value = (property?.value) ? String(property.value) : null;
+      const value = (property?.waarde) ? String(property.waarde) : null;
       const type = (zaaktypeEigenschap.spec.format === 'date') ? 'date' : null;
 
       return {
@@ -298,11 +298,11 @@ export class InformatieComponent implements OnInit, OnChanges {
     this.isCreatePropertyAPILoading = Object.entries(data).reduce((acc, [key, value], index) => {
       const newProperty: NieuweEigenschap = {
         naam: key,
-        value: value,
+        waarde: value,
         zaakUrl: this.mainZaakUrl
       }
 
-      if (newProperty.value) {
+      if (newProperty.waarde) {
         this.zaakService.createCaseProperty(newProperty).subscribe(
           () => {},
           this.reportError.bind(this),
@@ -321,7 +321,7 @@ export class InformatieComponent implements OnInit, OnChanges {
   updateProperties(data: Object): void {
     this.isPropertyAPILoading = Object.entries(data).reduce((acc, [key, value], index) => {
       const property = this.properties.find((propertyValue: EigenschapWaarde) => propertyValue.eigenschap.naam === key)
-      property.value = value;
+      property.waarde = value;
 
       this.zaakService.updateCaseProperty(property).subscribe(
         () => {},
@@ -357,7 +357,7 @@ export class InformatieComponent implements OnInit, OnChanges {
    * @param {*} error
    */
   reportError(error: any): void {
-    const message = error.error.value[0] || this.errorMessage;
+    const message = error.error?.value ? error.error?.value[0] : this.errorMessage;
     this.snackbarService.openSnackBar(message, 'Sluiten', 'warn');
     this.isCaseAPILoading = false;
     this.isPropertyAPILoading = 0;

--- a/frontend/zac-ui/libs/shared/data-access/models/zaken/zaak-eigenschap.ts
+++ b/frontend/zac-ui/libs/shared/data-access/models/zaken/zaak-eigenschap.ts
@@ -9,12 +9,12 @@ export interface EigenschapWaarde {
   eigenschap: Eigenschap;
   formaat: string;
   url: string;
-  value: string;
+  waarde: string;
 }
 
 export interface NieuweEigenschap {
   naam: string;
-  value: string;
+  waarde: string;
   zaakUrl: string;
 }
 

--- a/frontend/zac-ui/libs/shared/data-access/services/src/lib/zaak/zaak.service.ts
+++ b/frontend/zac-ui/libs/shared/data-access/services/src/lib/zaak/zaak.service.ts
@@ -95,14 +95,9 @@ export class ZaakService {
     const endpoint = encodeURI(`/api/core/cases/properties`);
     const params = new HttpParams().set('url', property.url)
     const waarde = property.waarde;
-    if (!waarde) {
-      return this.http.Delete(endpoint, {
-        params: params
-      })
-    }
 
     return this.http.Patch(endpoint, {
-      waarde: waarde,
+      waarde: waarde ? waarde : '-',
     }, {
       params: params,
     })

--- a/frontend/zac-ui/libs/shared/data-access/services/src/lib/zaak/zaak.service.ts
+++ b/frontend/zac-ui/libs/shared/data-access/services/src/lib/zaak/zaak.service.ts
@@ -94,15 +94,15 @@ export class ZaakService {
   updateCaseProperty(property: EigenschapWaarde):Observable<any> {
     const endpoint = encodeURI(`/api/core/cases/properties`);
     const params = new HttpParams().set('url', property.url)
-    const value = property.value;
-    if (!value) {
+    const waarde = property.waarde;
+    if (!waarde) {
       return this.http.Delete(endpoint, {
         params: params
       })
     }
 
     return this.http.Patch(endpoint, {
-      value: value,
+      waarde: waarde,
     }, {
       params: params,
     })


### PR DESCRIPTION
Fix a bug where open-zaak does not support (partial) updates to zaakeigenschappen. Workflow is now from within the backend: create new zaakeigenschap with old zaakeigenschap specifications and eigenschap and delete the old zaakeigenschap. FE still does a patch request.

Also wherever `value` was used, now `waarde` is used. This is to align the language in the API and prevent English and Dutch from being mixed around.

Fixes https://github.com/GemeenteUtrecht/ZGW/issues/1440