### PR TITLE
🐳 #1443 - Allow environment variables to be passed to the frontend.

### DIFF
--- a/frontend/zac-ui/Dockerfile
+++ b/frontend/zac-ui/Dockerfile
@@ -11,7 +11,15 @@ RUN ./node_modules/.bin/ng build --configuration production --base-href="$ui_pre
 # Stage 2 -- serve static build with nginx
 FROM nginxinc/nginx-unprivileged:1.20
 
+ENV ALFRESCO_AUTH_URL=https://alfresco-auth.cg-intern.acc.utrecht.nl/auth/realms/alfresco
+ENV ALFRESCO_PREVIEW_URL=https://alfresco-tezza.cg-intern.acc.utrecht.nl/
+ENV ALFRESCO_DOCUMENTS_URL=https://alfresco-tezza.aks.utrechtproeftuin.nl
+ENV FORMS_URL=https://formulieren.cg-intern.acc.utrecht.nl
+
 WORKDIR /apps
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist/apps/ .
+
+COPY ./bin/docker_start.sh /start.sh
+CMD ["/start.sh"]

--- a/frontend/zac-ui/Dockerfile-dev
+++ b/frontend/zac-ui/Dockerfile-dev
@@ -6,6 +6,13 @@ WORKDIR /app
 
 EXPOSE 4200
 
+ENV ALFRESCO_AUTH_URL=https://alfresco-auth.cg-intern.ont.utrecht.nl/auth/realms/alfresco
+ENV ALFRESCO_PREVIEW_URL=https://alfresco-tezza.cg-intern.ont.utrecht.nl/
+ENV ALFRESCO_DOCUMENTS_URL=https://alfresco-tezza.aks.utrechtproeftuin.nl
+ENV FORMS_URL=https://formulieren.cg-intern.ont.utrecht.nl
+
+RUN apt-get update && apt-get -y install gettext
+
 COPY ./bin/docker_dev_start.sh /start.sh
 CMD ["/start.sh"]
 

--- a/frontend/zac-ui/apps/zac-ui/src/app/constants/menu.ts
+++ b/frontend/zac-ui/apps/zac-ui/src/app/constants/menu.ts
@@ -1,5 +1,5 @@
 import { MenuItem } from '@gu/models';
-import {isTestEnvironment} from "@gu/utils";
+import {getEnv} from '@gu/utils';
 
 const menuItems: MenuItem[] = [
   {
@@ -30,7 +30,7 @@ const menuItems: MenuItem[] = [
   {
     icon: 'open_in_new',
     label: 'Alfresco',
-    to: isTestEnvironment() ? 'https://alfresco-tezza.cg-intern.ont.utrecht.nl/' : 'https://alfresco-tezza.cg-intern.acc.utrecht.nl/',
+    to: getEnv('ALFRESCO_PREVIEW_URL', 'https://alfresco-tezza.cg-intern.ont.utrecht.nl/'),
     external: true,
     adminOnly: false,
   },

--- a/frontend/zac-ui/bin/docker_dev_start.sh
+++ b/frontend/zac-ui/bin/docker_dev_start.sh
@@ -2,4 +2,10 @@
 
 set -e
 
-/app/node_modules/.bin/ng serve zac-ui --disable-host-check
+# Set environment variables.
+export NGSOURCEMAP=${SOURCEMAP:-false}
+
+# Start server.
+/app/node_modules/.bin/ng serve zac-ui --disable-host-check --sourceMap=$NGSOURCEMAP
+
+

--- a/frontend/zac-ui/bin/docker_start.sh
+++ b/frontend/zac-ui/bin/docker_start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Set environment variables.
+export EXISTING_VARS=$(printenv | awk -F= '{print $1}' | sed 's/^/\$/g' | paste -sd,);
+
+# Replace environment variables in source files.
+for i in `grep -r '\$ALFRESCO_' /apps/zac-ui/ --files-with-match`; do cat $i | envsubst $EXISTING_VARS | tee $i; done
+
+nginx -g "daemon off;"

--- a/frontend/zac-ui/libs/features/contezza-document-search/src/app.config.json
+++ b/frontend/zac-ui/libs/features/contezza-document-search/src/app.config.json
@@ -6,7 +6,7 @@
   "providers": "ECM",
   "authType": "OAUTH",
   "oauth2": {
-    "host": "https://alfresco-auth.cg-intern.acc.utrecht.nl/auth/realms/alfresco",
+    "host": "$ALFRESCO_AUTH_URL",
     "clientId": "alfresco",
     "scope": "openid",
     "secret": "",
@@ -24,5 +24,5 @@
   },
   "SEARCH_QUERY": "TYPE:'cm:content'",
   "SEARCH_FIELDS": ["cm:name", "cm:title", "cm:description"],
-  "ALFRESCO_PREVIEW_URL": "https://alfresco-tezza.cg-intern.acc.utrecht.nl/"
+  "ALFRESCO_PREVIEW_URL": "$ALFRESCO_PREVIEW_URL"
 }

--- a/frontend/zac-ui/libs/features/forms/src/lib/features-forms.service.ts
+++ b/frontend/zac-ui/libs/features/forms/src/lib/features-forms.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {ApplicationHttpClient} from '@gu/services';
 import {Observable} from 'rxjs';
 import {Form} from "./features-forms.model";
-import {isTestEnvironment} from "@gu/utils";
+import {getEnv} from "@gu/utils";
 
 @Injectable({
   providedIn: 'root'
@@ -27,12 +27,7 @@ export class FeaturesFormsService {
    * @return {string}
    */
   getAbsoluteFormURL(form: Form): string {
-    const useTestURL = isTestEnvironment();
-    const scheme = 'https://'
-    const hostname = useTestURL
-      ? 'formulieren.cg-intern.ont.utrecht.nl'
-      : 'formulieren.cg-intern.acc.utrecht.nl'
-
-    return `${scheme}${hostname}/forms/${form.slug}/`;
+    const formsURL = getEnv('FORMS_URL', 'https://formulieren.cg-intern.ont.utrecht.nl');
+    return `${formsURL}/forms/${form.slug}/`;
   }
 }

--- a/frontend/zac-ui/libs/shared/data-access/services/src/lib/zaak/zaak.service.ts
+++ b/frontend/zac-ui/libs/shared/data-access/services/src/lib/zaak/zaak.service.ts
@@ -4,7 +4,7 @@ import {Router} from '@angular/router';
 import {Observable} from 'rxjs';
 import {Document, RelatedCase, EigenschapWaarde, UserPermission, Zaak, NieuweEigenschap} from '@gu/models';
 import {ApplicationHttpClient} from '@gu/services';
-import {CachedObservableMethod, ClearCacheOnMethodCall, isTestEnvironment} from '@gu/utils';
+import {CachedObservableMethod, ClearCacheOnMethodCall, getEnv} from '@gu/utils';
 import {MapGeometry} from "../../../../../ui/components/src/lib/components/map/map";
 
 
@@ -195,7 +195,7 @@ export class ZaakService {
    */
   createTezzaUrl(zaak: Zaak): string {
     const zaakUuid = zaak.url.split('/api/v1/zaken/')[1]; // Extract case uuid from open zaak url
-    const tezzaHost = isTestEnvironment() ? 'https://alfresco-tezza.cg-intern.ont.utrecht.nl' : 'https://alfresco-tezza.cg-intern.acc.utrecht.nl';
+    const tezzaHost = getEnv('ALFRESCO_PREVIEW_URL', 'https://alfresco-tezza.cg-intern.ont.utrecht.nl/');
     return `${tezzaHost}/#/details/cases/${zaakUuid}`;
   }
 

--- a/frontend/zac-ui/libs/shared/utils/src/lib/helpers/environment.ts
+++ b/frontend/zac-ui/libs/shared/utils/src/lib/helpers/environment.ts
@@ -1,10 +1,24 @@
+// A mapping between the name of an environment variable, and its replacement target (to be substituted by envsubst).
+const SUPPORTED_ENV_VARS = {
+  "ALFRESCO_AUTH_URL": "$ALFRESCO_AUTH_URL",
+  "ALFRESCO_PREVIEW_URL": "$ALFRESCO_PREVIEW_URL",
+  "ALFRESCO_DOCUMENTS_URL": "$ALFRESCO_DOCUMENTS_URL",
+  "FORMS_URL": "$FORMS_URL",
+}
+
 /**
- * Returns whether the current environment is assumed to be a development environment.
- * A development environment is assumed when the current window's location matches 'test' or 'localhost'.
- * @TODO: Use a more solid check.
- * @return {Boolean}
+ * Returns the substituted value in SUPPORTED_ENV_VARS for envvar, or defaultValue.
+ * @param {string} envVar
+ * @param {*} defaultValue
+ * @return {*}
  */
-export const isTestEnvironment = () => {
-  const url = String(window.location);
-  return Boolean(url.match('ont') || url.match('localhost'));
+export const getEnv = (envVar: string, defaultValue: any): any => {
+  // In order to prevent unwanted code replacements, only occurrences starting with "$" are replaced.
+  // Therefore, code fragments calling getEnv should not include the dollar sign (to keep the code intact).
+  if(String(envVar).startsWith('$')) {
+    throw new Error(`Value for "value" (${envVar}) should not start with "$"`);
+  }
+
+  const value = SUPPORTED_ENV_VARS[envVar];
+  return (String(value).startsWith('$')) ? defaultValue : value;
 }

--- a/frontend/zac-ui/proxy.conf.js
+++ b/frontend/zac-ui/proxy.conf.js
@@ -1,6 +1,11 @@
+const ALFRESCO_DOCUMENTS_URL = '$ALFRESCO_DOCUMENTS_URL';
+
+// Still in use?
 module.exports = {
   '/alfresco': {
-    target: 'https://alfresco-tezza.aks.utrechtproeftuin.nl',
+    target: (ALFRESCO_DOCUMENTS_URL.startsWith('$'))
+      ? 'https://alfresco-tezza.aks.utrechtproeftuin.nl'
+      : ALFRESCO_DOCUMENTS_URL,
     secure: false,
     changeOrigin: true,
     onProxyRes: function(proxyRes, req, res) {


### PR DESCRIPTION
This changes the docker infratstructure and some frontend code to support environment variables for e.g. alfresco configuration. This is the first step in #1443.

@jordi-t can you check if this is correct?
@kelvincy can you check the frontend side?