### PR TITLE
:bug: #1562 - Het informatieveld (na klikken op de i) bij zoeken word…

### DIFF
--- a/frontend/zac-ui/libs/shared/ui/styling/src/lib/elements/_elements.tooltip.scss
+++ b/frontend/zac-ui/libs/shared/ui/styling/src/lib/elements/_elements.tooltip.scss
@@ -21,7 +21,7 @@
     margin: 2px 0;
     transition: 0.2s ease;
     opacity: 0.9;
-    min-width: 200px;
+    min-width: 300px;
     bottom: 26px;
     left: 16px;
     position: absolute;


### PR DESCRIPTION
…t niet volledig getoond.

https://github.com/GemeenteUtrecht/zaakafhandelcomponent/compare/issue%231562?expand=1