### PR TITLE
Feature/create zaak

### DIFF
--- a/backend/src/zac/camunda/api/urls.py
+++ b/backend/src/zac/camunda/api/urls.py
@@ -1,21 +1,26 @@
 from django.urls import path
 
+from rest_framework.routers import DefaultRouter
+
 from .views import (
     CancelTaskView,
     GetBPMNView,
-    ProcessInstanceFetchView,
+    ProcessInstanceFetchViewSet,
     SendMessageView,
     SetTaskAssigneeView,
     UserTaskHistoryView,
     UserTaskView,
 )
 
-urlpatterns = [
-    path(
-        "fetch-process-instances",
-        ProcessInstanceFetchView.as_view(),
-        name="fetch-process-instances",
-    ),
+router = DefaultRouter(trailing_slash=False)
+router.register(
+    "fetch-process-instances",
+    ProcessInstanceFetchViewSet,
+    basename="fetch-process-instances",
+)
+
+
+urlpatterns = router.urls + [
     path(
         "task-data/<uuid:task_id>",
         UserTaskView.as_view(),

--- a/backend/src/zac/camunda/api/utils.py
+++ b/backend/src/zac/camunda/api/utils.py
@@ -49,7 +49,7 @@ def start_process(
         "withVariablesInReturn": False,
         "variables": _variables,
     }
-    print(body)
+
     response = client.post(endpoint, json=body)
 
     self_rel = next((link for link in response["links"] if link["rel"] == "self"))

--- a/backend/src/zac/camunda/api/utils.py
+++ b/backend/src/zac/camunda/api/utils.py
@@ -1,6 +1,12 @@
-from typing import Dict
+import logging
+from typing import Dict, Optional, Union
+
+from django_camunda.client import get_client
+from django_camunda.interface import Variable
 
 from zac.core.models import CoreConfig
+
+logger = logging.getLogger(__name__)
 
 
 def get_bptl_app_id_variable() -> Dict[str, str]:
@@ -11,3 +17,44 @@ def get_bptl_app_id_variable() -> Dict[str, str]:
     return {
         "bptlAppId": core_config.app_id,
     }
+
+
+def start_process(
+    process_key: Optional[str] = None,
+    process_id: Optional[str] = None,
+    business_key: Optional[str] = None,
+    variables: Dict[str, Union[Variable, dict]] = None,
+) -> Dict[str, str]:
+    logger.debug(
+        "Received process start: process_key=%s, process_id=%s", process_key, process_id
+    )
+    if not (process_key or process_id):
+        raise ValueError("Provide a process key or process ID")
+
+    client = get_client()
+    variables = variables or {}
+
+    _variables = {
+        key: var.serialize() if isinstance(var, Variable) else var
+        for key, var in variables.items()
+    }
+
+    if process_id:
+        endpoint = f"process-definition/{process_id}/start"
+    else:
+        endpoint = f"process-definition/key/{process_key}/start"
+
+    body = {
+        "businessKey": business_key or "",
+        "withVariablesInReturn": False,
+        "variables": _variables,
+    }
+    print(body)
+    response = client.post(endpoint, json=body)
+
+    self_rel = next((link for link in response["links"] if link["rel"] == "self"))
+    instance_url = self_rel["href"]
+
+    logger.info("Started process instance %s", response["id"])
+
+    return {"instance_id": response["id"], "instance_url": instance_url}

--- a/backend/src/zac/camunda/api/views.py
+++ b/backend/src/zac/camunda/api/views.py
@@ -93,17 +93,18 @@ class ProcessInstanceFetchViewSet(ViewSet):
         summary=_("Retrieve ZAAK URL for process instance."),
         parameters=[
             OpenApiParameter(
-                name="process_instance_id",
+                name="pk",
                 type=OpenApiTypes.UUID,
                 location=OpenApiParameter.PATH,
                 required=True,
+                description="UUID of process instance",
             ),
         ],
         responses={"200": ZaakSerializer},
     )
     @action(detail=True, methods=["get"], permission_classes=(CanCreateZaken,))
-    def zaak(self, request: Request, process_instance_id: uuid.UUID):
-        process_instance = get_process_instance(process_instance_id)
+    def zaak(self, request: Request, pk: uuid.UUID):
+        process_instance = get_process_instance(pk)
         zaak_url = process_instance.get_variable("zaakUrl")
         zaak = get_zaak(zaak_url=zaak_url)
         serializer = ZaakSerializer(instance=zaak)

--- a/backend/src/zac/camunda/tests/test_fetch_process_instances.py
+++ b/backend/src/zac/camunda/tests/test_fetch_process_instances.py
@@ -177,7 +177,7 @@ class ProcessInstanceTests(TransactionTestCase):
     def test_fetch_process_instances(self, m_messages, m_task_from, m_request):
         self._setUpMock(m_request)
 
-        url = reverse("fetch-process-instances")
+        url = reverse("fetch-process-instances-list")
 
         response = self.client.get(url, {"zaak_url": ZAAK_URL})
 
@@ -263,7 +263,7 @@ class ProcessInstanceTests(TransactionTestCase):
     ):
         self._setUpMock(m_request)
 
-        url = reverse("fetch-process-instances")
+        url = reverse("fetch-process-instances-list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json(), {"detail": "missing zaak_url"})

--- a/backend/src/zac/camunda/tests/test_fetch_process_instances_view.py
+++ b/backend/src/zac/camunda/tests/test_fetch_process_instances_view.py
@@ -1,16 +1,22 @@
 from unittest.mock import patch
 
-from django.test.testcases import TransactionTestCase
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 import requests_mock
 from django_camunda.models import CamundaConfig
+from django_camunda.utils import serialize_variable
 from rest_framework import status
+from rest_framework.test import APITransactionTestCase
+from zgw_consumers.constants import APITypes
+from zgw_consumers.models import Service
+from zgw_consumers.test import generate_oas_component, mock_service_oas_get
 
-from zac.accounts.tests.factories import GroupFactory, UserFactory
+from zac.accounts.tests.factories import GroupFactory, SuperUserFactory, UserFactory
+from zac.tests.utils import mock_resource_get
 
-ZAAK_URL = "https://some.zrc.nl/api/v1/zaken/a955573e-ce3f-4cf3-8ae0-87853d61f47a"
+ZAKEN_ROOT = "https://some.zrc.nl/api/v1/"
+ZAAK_URL = f"{ZAKEN_ROOT}zaken/a955573e-ce3f-4cf3-8ae0-87853d61f47a"
 CAMUNDA_ROOT = "https://some.camunda.nl/"
 CAMUNDA_API_PATH = "engine-rest/"
 CAMUNDA_URL = f"{CAMUNDA_ROOT}{CAMUNDA_API_PATH}"
@@ -22,7 +28,7 @@ CAMUNDA_URL = f"{CAMUNDA_ROOT}{CAMUNDA_API_PATH}"
     return_value=["Annuleer behandeling", "Advies vragen"],
 )
 @requests_mock.Mocker()
-class ProcessInstanceTests(TransactionTestCase):
+class ProcessInstanceTests(APITransactionTestCase):
     def setUp(self) -> None:
         super().setUp()
         config = CamundaConfig.get_solo()
@@ -32,10 +38,11 @@ class ProcessInstanceTests(TransactionTestCase):
 
         self.user = UserFactory.create()
         self.group = GroupFactory.create()
+
         self.client.force_login(self.user)
 
-    def _setUpMock(self, m):
-        self.process_definition_data = [
+    def test_fetch_process_instances(self, m_messages, m_task_from, m_request):
+        process_definition_data = [
             {
                 "id": f"{key}:8:c76c8200-c766-11ea-86dc-e22fafe5f405",
                 "key": key,
@@ -54,10 +61,10 @@ class ProcessInstanceTests(TransactionTestCase):
             }
             for key in ["Aanvraag_behandelen", "accorderen", "Bezwaar_indienen"]
         ]
-        self.process_instance_data = [
+        process_instance_data = [
             {
                 "id": "205eae6b-d26f-11ea-86dc-e22fafe5f405",
-                "definitionId": self.process_definition_data[0]["id"],
+                "definitionId": process_definition_data[0]["id"],
                 "businessKey": "",
                 "caseInstanceId": "",
                 "suspended": False,
@@ -65,7 +72,7 @@ class ProcessInstanceTests(TransactionTestCase):
             },
             {
                 "id": "905abd5f-d26f-11ea-86dc-e22fafe5f405",
-                "definitionId": self.process_definition_data[1]["id"],
+                "definitionId": process_definition_data[1]["id"],
                 "businessKey": "",
                 "caseInstanceId": "",
                 "suspended": False,
@@ -73,14 +80,14 @@ class ProcessInstanceTests(TransactionTestCase):
             },
             {
                 "id": "010fe90d-c122-11ea-a817-b6551116eb32",
-                "definitionId": self.process_definition_data[2]["id"],
+                "definitionId": process_definition_data[2]["id"],
                 "businessKey": "",
                 "caseInstanceId": "",
                 "suspended": False,
                 "tenantId": "",
             },
         ]
-        self.task_data = [
+        task_data = [
             [],
             [
                 {
@@ -155,51 +162,45 @@ class ProcessInstanceTests(TransactionTestCase):
             ],
             [],
         ]
-
-        m.get(
+        m_request.get(
             f"{CAMUNDA_URL}process-instance?variables=zaakUrl_eq_{ZAAK_URL}",
-            json=[self.process_instance_data[0]],
+            json=[process_instance_data[0]],
         )
-        m.get(
-            f"{CAMUNDA_URL}process-definition?processDefinitionIdIn={','.join([d['id'] for d in self.process_definition_data])}",
-            json=self.process_definition_data,
+        m_request.get(
+            f"{CAMUNDA_URL}process-definition?processDefinitionIdIn={','.join([d['id'] for d in process_definition_data])}",
+            json=process_definition_data,
         )
-        for i, process in enumerate(self.process_instance_data):
-            m.get(
+        for i, process in enumerate(process_instance_data):
+            m_request.get(
                 f"{CAMUNDA_URL}process-instance?superProcessInstance={process['id']}",
-                json=[self.process_instance_data[i + 1]] if i < 2 else [],
+                json=[process_instance_data[i + 1]] if i < 2 else [],
             )
-            m.get(
+            m_request.get(
                 f"{CAMUNDA_URL}task?processInstanceId={process['id']}",
-                json=self.task_data[i],
+                json=task_data[i],
             )
-
-    def test_fetch_process_instances(self, m_messages, m_task_from, m_request):
-        self._setUpMock(m_request)
 
         url = reverse("fetch-process-instances-list")
-
         response = self.client.get(url, {"zaak_url": ZAAK_URL})
-
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.maxDiff = None
+
         data = response.json()
         expected_data = [
             {
-                "id": self.process_instance_data[0]["id"],
-                "definitionId": self.process_instance_data[0]["definitionId"],
-                "title": self.process_definition_data[0]["key"],
+                "id": process_instance_data[0]["id"],
+                "definitionId": process_instance_data[0]["definitionId"],
+                "title": process_definition_data[0]["key"],
                 "messages": ["Annuleer behandeling", "Advies vragen"],
                 "tasks": [],
                 "subProcesses": [
                     {
-                        "id": self.process_instance_data[1]["id"],
-                        "definitionId": self.process_instance_data[1]["definitionId"],
-                        "title": self.process_definition_data[1]["key"],
+                        "id": process_instance_data[1]["id"],
+                        "definitionId": process_instance_data[1]["definitionId"],
+                        "title": process_definition_data[1]["key"],
                         "messages": [],
                         "tasks": [
                             {
-                                "id": self.task_data[1][0]["id"],
+                                "id": task_data[1][0]["id"],
                                 "name": "Accorderen",
                                 "created": "2020-07-30T14:19:06Z",
                                 "hasForm": False,
@@ -217,7 +218,7 @@ class ProcessInstanceTests(TransactionTestCase):
                                 "canCancelTask": False,
                             },
                             {
-                                "id": self.task_data[1][1]["id"],
+                                "id": task_data[1][1]["id"],
                                 "name": "Accorderen",
                                 "created": "2020-07-30T14:19:06Z",
                                 "hasForm": False,
@@ -230,7 +231,7 @@ class ProcessInstanceTests(TransactionTestCase):
                                 "canCancelTask": False,
                             },
                             {
-                                "id": self.task_data[1][2]["id"],
+                                "id": task_data[1][2]["id"],
                                 "name": "Accorderen",
                                 "created": "2020-07-30T14:19:06Z",
                                 "hasForm": False,
@@ -241,11 +242,11 @@ class ProcessInstanceTests(TransactionTestCase):
                         ],
                         "subProcesses": [
                             {
-                                "id": self.process_instance_data[2]["id"],
-                                "definitionId": self.process_instance_data[2][
+                                "id": process_instance_data[2]["id"],
+                                "definitionId": process_instance_data[2][
                                     "definitionId"
                                 ],
-                                "title": self.process_definition_data[2]["key"],
+                                "title": process_definition_data[2]["key"],
                                 "messages": [],
                                 "tasks": [],
                                 "subProcesses": [],
@@ -261,9 +262,53 @@ class ProcessInstanceTests(TransactionTestCase):
     def test_fail_fetch_process_instances_no_zaak_url(
         self, m_messages, m_task_from, m_request
     ):
-        self._setUpMock(m_request)
-
         url = reverse("fetch-process-instances-list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json(), {"detail": "missing zaak_url"})
+
+    def test_fetch_zaak_url_from_process_instance(
+        self, m_messages, m_task_from, m_request
+    ):
+        Service.objects.create(api_type=APITypes.zrc, api_root=ZAKEN_ROOT)
+        mock_service_oas_get(m_request, ZAKEN_ROOT, "zrc")
+
+        zaak = generate_oas_component(
+            "zrc",
+            "schemas/Zaak",
+            url=ZAAK_URL,
+        )
+        mock_resource_get(m_request, zaak)
+
+        m_request.get(
+            f"{CAMUNDA_URL}process-instance/205eae6b-d26f-11ea-86dc-e22fafe5f405",
+            json={
+                "id": "205eae6b-d26f-11ea-86dc-e22fafe5f405",
+                "definitionId": "Aanvraag_behandelen:8:c76c8200-c766-11ea-86dc-e22fafe5f405",
+                "businessKey": "",
+                "caseInstanceId": "",
+                "suspended": False,
+                "tenantId": "",
+            },
+        )
+        m_request.get(
+            f"{CAMUNDA_URL}process-instance/205eae6b-d26f-11ea-86dc-e22fafe5f405/variables/zaakUrl?deserializeValue=false",
+            json=serialize_variable(ZAAK_URL),
+        )
+        url = reverse(
+            "fetch-process-instances-zaak",
+            kwargs={"pk": "205eae6b-d26f-11ea-86dc-e22fafe5f405"},
+        )
+        superuser = SuperUserFactory.create()
+        self.client.force_login(superuser)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "bronorganisatie": zaak["bronorganisatie"],
+                "identificatie": zaak["identificatie"],
+                "url": ZAAK_URL,
+            },
+        )

--- a/backend/src/zac/camunda/tests/test_user_task_cancel.py
+++ b/backend/src/zac/camunda/tests/test_user_task_cancel.py
@@ -4,7 +4,7 @@ from django.urls import reverse_lazy
 
 import requests_mock
 from django_camunda.models import CamundaConfig
-from django_camunda.utils import deserialize_variable, serialize_variable
+from django_camunda.utils import serialize_variable
 from rest_framework.test import APITransactionTestCase
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 from zgw_consumers.constants import APITypes

--- a/backend/src/zac/conf/includes/base.py
+++ b/backend/src/zac/conf/includes/base.py
@@ -121,7 +121,7 @@ INSTALLED_APPS = [
     "sniplates",
     "zgw_consumers",
     "django_camunda",
-    "django_extensions",
+    # "django_extensions",
     "import_export",
     "django_auth_adfs",
     "django_auth_adfs_db",
@@ -568,3 +568,6 @@ SCIM_SERVICE_PROVIDER = {
 
 # Custom settings
 UI_ROOT_URL = config("UI_ROOT_URL", default="/ui")
+CREATE_ZAAK_PROCESS_DEFINITION_KEY = config(
+    "CREATE_ZAAK_PROCESS_DEFINITION_KEY", default="zaak_aanmaken"
+)

--- a/backend/src/zac/conf/includes/base.py
+++ b/backend/src/zac/conf/includes/base.py
@@ -121,6 +121,7 @@ INSTALLED_APPS = [
     "sniplates",
     "zgw_consumers",
     "django_camunda",
+    "django_extensions",
     "import_export",
     "django_auth_adfs",
     "django_auth_adfs_db",

--- a/backend/src/zac/core/api/bff_urls.py
+++ b/backend/src/zac/core/api/bff_urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from .views import (
     CreateZaakRelationView,
+    CreateZaakView,
     EigenschappenView,
     InformatieObjectTypeListView,
     ListZaakDocumentsView,
@@ -25,6 +26,7 @@ from .views import (
 
 urlpatterns = [
     # core zgw
+    path("cases", CreateZaakView.as_view(), name="zaak-create"),
     path(
         "cases/<str:bronorganisatie>/<str:identificatie>",
         ZaakDetailView.as_view(),

--- a/backend/src/zac/core/api/permissions.py
+++ b/backend/src/zac/core/api/permissions.py
@@ -12,6 +12,7 @@ from zac.api.permissions import (
 )
 
 from ..permissions import (
+    zaken_aanmaken,
     zaken_add_documents,
     zaken_add_relations,
     zaken_download_documents,
@@ -129,6 +130,10 @@ class CanReadOrUpdateZaken(BaseConditionalPermission):
             return CanReadZaken()
         else:
             return CanUpdateZaken()
+
+
+class CanCreateZaken(DefinitionBasePermission):
+    permission = zaken_aanmaken
 
 
 ###############################

--- a/backend/src/zac/core/api/serializers.py
+++ b/backend/src/zac/core/api/serializers.py
@@ -34,6 +34,8 @@ from zac.accounts.api.serializers import AtomicPermissionSerializer
 from zac.accounts.models import User
 from zac.api.polymorphism import PolymorphicSerializer
 from zac.api.proxy import ProxySerializer
+from zac.camunda.api.utils import get_bptl_app_id_variable
+from zac.camunda.constants import AssigneeTypeChoices
 from zac.contrib.dowc.constants import DocFileTypes
 from zac.contrib.dowc.fields import DowcUrlFieldReadOnly
 from zac.core.rollen import Rol
@@ -350,7 +352,7 @@ class CreateZaakSerializer(serializers.Serializer):
         help_text=_("URL-reference to the ZAAKTYPE (in the Catalogi API)."),
     )
     omschrijving = serializers.CharField(
-        required=False, help_text=_("A short summary of the ZAAK.")
+        required=True, help_text=_("A short summary of the ZAAK.")
     )
     toelichting = serializers.CharField(
         required=False, help_text=_("A comment on the ZAAK.")
@@ -373,9 +375,11 @@ class CreateZaakSerializer(serializers.Serializer):
         raise serializers.ValidationError(_("ZAAKTYPE not found."))
 
     def to_internal_value(self, data):
-        data = super().to_internal_value(data)
-        serialized_data = {}
-        for key, value in data.items():
+        serialized_data = {
+            **super().to_internal_value(data),
+            **get_bptl_app_id_variable(),
+        }
+        for key, value in serialized_data.items():
             serialized_data[key] = serialize_variable(value)
 
         organisatie_rsin = serialized_data.pop("organisatie_rsin")

--- a/backend/src/zac/core/api/serializers.py
+++ b/backend/src/zac/core/api/serializers.py
@@ -1,5 +1,5 @@
 import pathlib
-from datetime import datetime
+from datetime import date, datetime
 from decimal import ROUND_05UP
 from typing import Optional
 
@@ -336,8 +336,7 @@ class CreateZaakSerializer(serializers.Serializer):
         help_text=_(
             "The RSIN of the organization that created the ZAAK. This has to be a valid `RSIN` of 9 digits and comply to https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef."
         ),
-        allow_blank=False,
-        required=True,
+        default="002220647",
         max_length=9,
         validators=[
             RegexValidator(
@@ -355,7 +354,10 @@ class CreateZaakSerializer(serializers.Serializer):
         required=True, help_text=_("A short summary of the ZAAK.")
     )
     toelichting = serializers.CharField(
-        required=False, help_text=_("A comment on the ZAAK.")
+        help_text=_("A comment on the ZAAK."), default=""
+    )
+    startdatum = serializers.DateField(
+        default=date.today(), help_text=_("The date the ZAAK begins.")
     )
 
     def validate_zaaktype(self, zaaktype):

--- a/backend/src/zac/core/api/validators.py
+++ b/backend/src/zac/core/api/validators.py
@@ -56,7 +56,6 @@ class ZaakFileValidator:
                 "Only alphanumerical characters, whitespaces, -_() and 1 file extension are allowed."
             )
 
-        print(value.content_type)
         if value.content_type.lower() not in ACCEPTABLE_CONTENT_TYPES.values():
             raise exceptions.ValidationError(
                 f"File format not allowed. Please use one of the following file formats: {', '.join(ACCEPTABLE_CONTENT_TYPES)}."

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from itertools import groupby
 from typing import Dict, List, Optional
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.http import Http404
@@ -220,7 +221,7 @@ class GetZaakMixin:
 
 
 class CreateZaakView(views.APIView):
-    # authentication_classes = (authentication.SessionAuthentication,)
+    authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (
         permissions.IsAuthenticated,
         CanCreateZaken,
@@ -249,7 +250,8 @@ class CreateZaakView(views.APIView):
         )
         serializer.is_valid(raise_exception=True)
         details = start_process(
-            process_key="spike_zaak_via_zac", variables=serializer.validated_data
+            process_key=settings.CREATE_ZAAK_PROCESS_DEFINITION_KEY,
+            variables=serializer.validated_data,
         )
         return Response(details)
 

--- a/backend/src/zac/core/permissions.py
+++ b/backend/src/zac/core/permissions.py
@@ -1,5 +1,10 @@
 from zac.accounts.permissions import Permission
 
+zaken_aanmaken = Permission(
+    name="zaken:aanmaken",
+    description="Laa toe om zaken aan te maken.",
+)
+
 zaken_inzien = Permission(
     name="zaken:inzien",
     description="Laat toe om zaken/zaakdossiers in te zien.",
@@ -19,7 +24,6 @@ zaakproces_send_message = Permission(
     name="zaakproces:send-bpmn-message",
     description="BPMN messages versturen in het proces.",
 )
-
 
 zaken_close = Permission(
     name="zaken:afsluiten",


### PR DESCRIPTION
Lets users create a zaak through a camunda process. Frontend can poll the URL of the returned process instance for zaak url.