### PR TITLE
:sparkles: Zaak annuleren now fetches choices from BPMN if configured

### DIFF
--- a/backend/src/zac/camunda/tests/test_user_task_view.py
+++ b/backend/src/zac/camunda/tests/test_user_task_view.py
@@ -465,7 +465,10 @@ class GetUserTaskContextViewTests(APITestCase):
             "schemas/ResultaatType",
             catalogus=self.zaaktype["catalogus"],
         )
-
+        m.get(
+            "https://camunda.example.com/engine-rest/task/598347ee-62fc-46a2-913a-6e0788bc1b8c/variables/resultaatTypeKeuzes?deserializeValue=false",
+            json=serialize_variable([resultaattype["omschrijving"]]),
+        )
         BlueprintPermissionFactory.create(
             role__permissions=[zaakproces_usertasks.name],
             for_user=self.user,

--- a/backend/src/zac/core/camunda/zet_resultaat/context.py
+++ b/backend/src/zac/core/camunda/zet_resultaat/context.py
@@ -81,11 +81,18 @@ def get_context(task: Task) -> ZetResultaatContext:
         rr for rr in get_review_requests(zaak) if rr.completed < rr.num_assigned_users
     ] or None
     zaaktype = fetch_zaaktype(zaak.zaaktype)
-    result_types = get_resultaattypen(zaaktype)
+
+    all_result_types = get_resultaattypen(zaaktype)
+    chosen_result_types = []
+    if result_type_choices := task.get_variable("resultaatTypeKeuzes", default=None):
+        for result in all_result_types:
+            if result.omschrijving in result_type_choices:
+                chosen_result_types.append(result)
+
     return ZetResultaatContext(
         activities=activities,
         checklist_questions=checklist_questions,
         tasks=tasks,
         review_requests=review_requests,
-        result_types=result_types,
+        result_types=chosen_result_types or all_result_types,
     )

--- a/backend/src/zac/core/tests/test_zet_resultaat.py
+++ b/backend/src/zac/core/tests/test_zet_resultaat.py
@@ -184,6 +184,10 @@ class GetZetResultaatContextSerializersTests(APITestCase):
             f"{CAMUNDA_URL}task/{task.id}/variables/zaakUrl?deserializeValue=false",
             json=serialize_variable(self.zaak["url"]),
         )
+        m.get(
+            f"{CAMUNDA_URL}task/{task.id}/variables/resultaatTypeKeuzes?deserializeValue=false",
+            json=serialize_variable([self.resultaattype["omschrijving"]]),
+        )
         mock_resource_get(m, self.zaak)
         m.get(
             f"{KOWNSL_ROOT}api/v1/review-requests?for_zaak={self.zaak['url']}",

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.component.html
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.component.html
@@ -151,7 +151,8 @@
   <!-- Action buttons -->
   <div class="processen__msg-btns-container">
     <ng-container *ngFor="let message of data[0].messages; let i = index">
-      <button gu-button
+      <button *ngIf="message !== 'Zaak annuleren'"
+              gu-button
               (click)="sendMessage(message)"
               buttonStyle="action-link"
               class="mr-2 mb-3">
@@ -159,12 +160,12 @@
       </button>
     </ng-container>
   </div>
-  <button *ngIf="closeCaseTask"
+  <button *ngIf="hasCancelCaseMessage"
           gu-button
           buttonStyle="primary"
           buttonType="danger"
           icon="dangerous"
-          (click)="executeTask(closeCaseTask.id, 0)"
+          (click)="sendMessage('Zaak annuleren')"
   >
     Zaak annuleren
   </button>

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.component.ts
@@ -83,7 +83,7 @@ export class KetenProcessenComponent implements OnChanges, OnDestroy, AfterViewI
   showOverlay: boolean;
   showActions: boolean;
 
-  closeCaseTask: Task;
+  hasCancelCaseMessage: boolean;
 
   constructor(
     public ketenProcessenService: KetenProcessenService,
@@ -208,10 +208,10 @@ export class KetenProcessenComponent implements OnChanges, OnDestroy, AfterViewI
 
   /**
    * Set task that is responsible for closing the case.
-   * @param {Task[]} data
+   * @param {string[]} messages
    */
-  setCloseCaseTask(data: Task[]) {
-    this.closeCaseTask = data.find(({formKey}) => formKey === 'zac:zetResultaat');
+  setCloseCaseMessage(messages: string[]) {
+    this.hasCancelCaseMessage = messages.includes('Zaak annuleren');
   }
 
   /**
@@ -275,7 +275,7 @@ export class KetenProcessenComponent implements OnChanges, OnDestroy, AfterViewI
       this.snackbarService.openSnackBar(sendMessageConfirmation, 'Sluiten', 'primary')
     }, errorRes => {
       this.isLoading = false;
-      this.errorMessage = errorRes?.error?.detail || 'Het openen van de taak is niet gelukt. Probeer het nog eens.';
+      this.errorMessage = errorRes?.error?.detail || 'Het openen van de actie is niet gelukt. Controleer of de actie al actief is in het "Acties" blok hierboven.';
       this.reportError(errorRes);
     })
   }
@@ -289,14 +289,15 @@ export class KetenProcessenComponent implements OnChanges, OnDestroy, AfterViewI
     this.data = data;
     this.allTaskData = this.ketenProcessenService.mergeTaskData(data);
 
-    this.setCloseCaseTask(this.allTaskData);
+    this.setCloseCaseMessage(data[0]?.messages || []);
 
     // Process instance ID for API calls
     this.processInstanceId = data.length > 0 ? data[0].id : null;
 
+    this.nVisibleTaskData = this.allTaskData.length;
+
     // Emit number of tasks
-    this.nVisibleTaskData = this.closeCaseTask ? this.allTaskData.length - 1 : this.allTaskData.length
-    this.nTaskDataEvent.emit(this.nVisibleTaskData);
+    this.nTaskDataEvent.emit(this.allTaskData.length);
 
     // Trigger update in parent
     this.update.emit(data);

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.service.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.service.ts
@@ -26,7 +26,7 @@ export class KetenProcessenService {
    * @returns {boolean}
    */
   isTaskForCurrentUser(user: User, task: Task): boolean {
-    return (task.assignee?.username === user.username || user.groups.includes(task.assignee?.name)) && task.formKey !== 'zac:zetResultaat';
+    return (task.assignee?.username === user.username || user.groups.includes(task.assignee?.name));
   }
 
   /**
@@ -36,7 +36,7 @@ export class KetenProcessenService {
    * @returns {boolean}
    */
   isTaskForOtherUser(user: User, task: Task): boolean {
-    return (task.assignee?.username !== user.username && !user.groups.includes(task.assignee?.name)) && task.formKey !== 'zac:zetResultaat'
+    return (task.assignee?.username !== user.username && !user.groups.includes(task.assignee?.name));
   }
 
   /**


### PR DESCRIPTION
Related to https://github.com/GemeenteUtrecht/ZGW/issues/1704