### PR TITLE
:sparkles: Allow filtering zaaktypen on catalogus domein

### DIFF
--- a/backend/src/zac/core/api/bff_urls.py
+++ b/backend/src/zac/core/api/bff_urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 
 from .views import (
+    CatalogiView,
     CreateZaakRelationView,
     CreateZaakView,
     EigenschappenView,
@@ -86,6 +87,7 @@ urlpatterns = [
         include("zac.core.camunda.start_process.urls"),
     ),
     # meta
+    path("catalogi", CatalogiView.as_view(), name="catalogi"),
     path("zaaktypen", ZaakTypenView.as_view(), name="zaaktypen"),
     path("eigenschappen", EigenschappenView.as_view(), name="eigenschappen"),
     path(

--- a/backend/src/zac/core/api/tests/test_catalogi.py
+++ b/backend/src/zac/core/api/tests/test_catalogi.py
@@ -1,0 +1,88 @@
+from django.urls import reverse
+
+import requests_mock
+from rest_framework import status
+from rest_framework.test import APITestCase
+from zgw_consumers.constants import APITypes
+from zgw_consumers.models import Service
+from zgw_consumers.test import generate_oas_component, mock_service_oas_get
+
+from zac.accounts.tests.factories import SuperUserFactory, UserFactory
+from zac.core.tests.utils import ClearCachesMixin
+from zac.tests.utils import paginated_response
+
+CATALOGI_ROOT = "http://catalogus.nl/api/v1/"
+CATALOGUS_URL = f"{CATALOGI_ROOT}/catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
+
+
+@requests_mock.Mocker()
+class CatalogiPermissiontests(ClearCachesMixin, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        Service.objects.create(api_type=APITypes.ztc, api_root=CATALOGI_ROOT)
+
+        cls.catalogus = generate_oas_component(
+            "ztc", "schemas/Catalogus", url=CATALOGUS_URL, domein="some-domein"
+        )
+
+        cls.endpoint = reverse("catalogi")
+
+    def test_not_authenticated(self, m):
+        response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authenticated(self, m):
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        m.get(
+            f"{CATALOGI_ROOT}catalogussen",
+            json=paginated_response([self.catalogus]),
+        )
+        user = UserFactory.create()
+        self.client.force_authenticate(user=user)
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+
+
+@requests_mock.Mocker()
+class CatalogiResponseTests(ClearCachesMixin, APITestCase):
+    """
+    Test the API response body for catalogi endpoint.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+        Service.objects.create(api_type=APITypes.ztc, api_root=CATALOGI_ROOT)
+
+        cls.endpoint = reverse("catalogi")
+
+    def setUp(self):
+        super().setUp()
+
+        # ensure that we have a user with all permissions
+        self.client.force_authenticate(user=self.user)
+
+    def test_list_catalogi(self, m):
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        catalogus = generate_oas_component(
+            "ztc", "schemas/Catalogus", url=CATALOGUS_URL, domein="some-domein"
+        )
+        m.get(
+            f"{CATALOGI_ROOT}catalogussen",
+            json=paginated_response([catalogus]),
+        )
+
+        response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(), [{"domein": "some-domein", "url": CATALOGUS_URL}]
+        )

--- a/backend/src/zac/core/api/tests/test_zaaktypen.py
+++ b/backend/src/zac/core/api/tests/test_zaaktypen.py
@@ -18,7 +18,7 @@ from zac.core.tests.utils import ClearCachesMixin
 from zac.tests.utils import paginated_response
 
 CATALOGI_ROOT = "http://catalogus.nl/api/v1/"
-CATALOGUS_URL = f"{CATALOGI_ROOT}/catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
+CATALOGUS_URL = f"{CATALOGI_ROOT}catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd"
 
 
 @requests_mock.Mocker()
@@ -364,4 +364,103 @@ class ZaaktypenResponseTests(ClearCachesMixin, APITestCase):
                     },
                 ],
             },
+        )
+
+    def test_get_with_filter_domein(self, m):
+        catalogus = generate_oas_component(
+            "ztc", "schemas/Catalogus", url=CATALOGUS_URL, domein="some-domein"
+        )
+        zaaktype_1 = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=f"{CATALOGI_ROOT}zaaktypen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            identificatie="ZT1",
+            catalogus=CATALOGUS_URL,
+            omschrijving="some zaaktype 1",
+        )
+        catalogus_2 = generate_oas_component(
+            "ztc",
+            "schemas/Catalogus",
+            url=f"{CATALOGI_ROOT}catalogussen/67a31e08-f167-492b-b765-c7b90c472b27",
+            domein="some-other-domein",
+        )
+        zaaktype_2 = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=f"{CATALOGI_ROOT}zaaktypen/2a51b38d-efc0-4f7e-9b95-a8c2374c1ac0",
+            identificatie="ZT2",
+            catalogus=catalogus_2["url"],
+            omschrijving="some zaaktype 2",
+        )
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        m.get(
+            f"{CATALOGI_ROOT}zaaktypen",
+            json=paginated_response([zaaktype_1, zaaktype_2]),
+        )
+        m.get(
+            f"{CATALOGI_ROOT}catalogussen",
+            json=paginated_response([catalogus, catalogus_2]),
+        )
+
+        response = self.client.get(self.endpoint, {"domein": "some-domein"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "omschrijving": "some zaaktype 1",
+                        "catalogus": {"domein": "some-domein", "url": CATALOGUS_URL},
+                        "identificatie": "ZT1",
+                    },
+                ],
+            },
+        )
+
+    def test_fail_get_with_filter_domein(self, m):
+        catalogus = generate_oas_component(
+            "ztc", "schemas/Catalogus", url=CATALOGUS_URL, domein="some-domein"
+        )
+        zaaktype_1 = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=f"{CATALOGI_ROOT}zaaktypen/3e2a1218-e598-4bbe-b520-cb56b0584d60",
+            identificatie="ZT1",
+            catalogus=CATALOGUS_URL,
+            omschrijving="some zaaktype 1",
+        )
+        catalogus_2 = generate_oas_component(
+            "ztc",
+            "schemas/Catalogus",
+            url=f"{CATALOGI_ROOT}catalogussen/67a31e08-f167-492b-b765-c7b90c472b27",
+            domein="some-other-domein",
+        )
+        zaaktype_2 = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            url=f"{CATALOGI_ROOT}zaaktypen/2a51b38d-efc0-4f7e-9b95-a8c2374c1ac0",
+            identificatie="ZT2",
+            catalogus=catalogus_2["url"],
+            omschrijving="some zaaktype 2",
+        )
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        m.get(
+            f"{CATALOGI_ROOT}zaaktypen",
+            json=paginated_response([zaaktype_1, zaaktype_2]),
+        )
+        m.get(
+            f"{CATALOGI_ROOT}catalogussen",
+            json=paginated_response([catalogus, catalogus_2]),
+        )
+
+        response = self.client.get(self.endpoint, {"domein": "some-random-domein"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            ["Could not find a CATALOGUS with `domein`: `some-random-domein`."],
         )

--- a/backend/src/zac/core/api/views.py
+++ b/backend/src/zac/core/api/views.py
@@ -121,6 +121,7 @@ from .permissions import (
 from .serializers import (
     AddZaakDocumentSerializer,
     AddZaakRelationSerializer,
+    CatalogusSerializer,
     CreateZaakEigenschapSerializer,
     CreateZaakSerializer,
     DestroyRolSerializer,
@@ -943,6 +944,21 @@ class InformatieObjectTypeListView(ListAPIView):
         if not zaak_url:
             raise exceptions.ValidationError("'zaak' query parameter is required.")
         return get_informatieobjecttypen_for_zaak(zaak_url)
+
+
+@extend_schema(summary=_("List CATALOGI."), tags=["meta"])
+class CatalogiView(views.APIView):
+    """
+    List a collection of catalogi.
+
+    """
+
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = CatalogusSerializer
+
+    def get(self, request, *args, **kwargs):
+        return Response(self.serializer_class(get_catalogi(), many=True).data)
 
 
 @extend_schema(summary=_("List ZAAKTYPEs."), tags=["meta"])


### PR DESCRIPTION
Related to https://github.com/GemeenteUtrecht/ZGW/issues/1765

See http://localhost:8000/api/docs/#tag/meta/operation/core_catalogi_retrieve for list catalogus
See http://localhost:8000/api/docs/#tag/meta/operation/core_zaaktypen_list for domein filtering on zaaktype 