### PR TITLE
:sparkles: 2120 - checklist lock

### DIFF
--- a/backend/src/zac/contrib/objects/checklists/api/permissions.py
+++ b/backend/src/zac/contrib/objects/checklists/api/permissions.py
@@ -1,10 +1,15 @@
 import logging
+from typing import Dict, Union
 
+from django.http import Http404
+
+from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.views import APIView
 
 from zac.api.permissions import DefinitionBasePermission, ZaakDefinitionPermission
 from zac.core.services import find_zaak
+from zgw.models.zrc import Zaak
 
 from ..permissions import checklists_inzien, checklists_schrijven, checklisttypes_inzien
 
@@ -17,7 +22,7 @@ class CanReadOrWriteChecklistsPermission(ZaakDefinitionPermission):
             return checklists_inzien
         return checklists_schrijven
 
-    def has_permission(self, request: Request, view: ModelViewSet):
+    def has_permission(self, request: Request, view: APIView) -> bool:
         if request.user.is_superuser:
             return True
 
@@ -30,10 +35,34 @@ class CanReadOrWriteChecklistsPermission(ZaakDefinitionPermission):
         return self.has_object_permission(request, view, zaak)
 
 
+class ChecklistIsUnlockedOrLockedByCurrentUser(BasePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if request.user.is_superuser:
+            return True
+        try:
+            checklist_object = view.get_checklist_object()
+        except Http404:  # Allow user to create a checklist or return a 404 message instead of 403.
+            return True
+        return self.has_object_permission(request, view, checklist_object)
+
+    def has_object_permission(
+        self, request: Request, view: APIView, obj: Union[Zaak, Dict]
+    ) -> bool:
+        if request.user.is_superuser:
+            return True
+
+        if isinstance(obj, Zaak):
+            obj = view.get_checklist_object()
+
+        if username := obj["record"]["data"]["lockedBy"]:
+            return request.user.username == username
+        return True
+
+
 class CanReadZaakChecklistTypePermission(DefinitionBasePermission):
     permission = checklisttypes_inzien
 
-    def has_permission(self, request: Request, view: ModelViewSet):
+    def has_permission(self, request: Request, view: APIView) -> bool:
         if request.user.is_superuser or request.user.is_staff:
             return True
 

--- a/backend/src/zac/contrib/objects/checklists/api/serializers.py
+++ b/backend/src/zac/contrib/objects/checklists/api/serializers.py
@@ -12,11 +12,7 @@ from zgw_consumers.drf.serializers import APIModelSerializer
 
 from zac.accounts.api.fields import GroupSlugRelatedField, UserSlugRelatedField
 from zac.accounts.models import User
-from zac.contrib.objects.services import (
-    fetch_checklist,
-    fetch_checklist_object,
-    fetch_checklisttype,
-)
+from zac.contrib.objects.services import fetch_checklist, fetch_checklisttype
 from zac.core.models import MetaObjectTypesConfig
 from zac.core.services import (
     create_object,
@@ -260,26 +256,3 @@ class ChecklistSerializer(APIModelSerializer):
             user=self.context["request"].user,
         )
         return factory(Checklist, self.validated_data)
-
-    def lock(self) -> Checklist:
-        checklist_obj = self.context["checklist_object"]
-        checklist_obj["record"]["data"]["lockedBy"] = self.context[
-            "request"
-        ].user.username
-
-        checklist = update_object_record_data(
-            object=checklist_obj,
-            data=checklist_obj["record"]["data"],
-            user=self.context["request"].user,
-        )
-        return factory(Checklist, checklist["record"]["data"])
-
-    def unlock(self) -> Checklist:
-        checklist_obj = self.context["checklist_object"]
-        checklist_obj["record"]["data"]["lockedBy"] = None
-        checklist = update_object_record_data(
-            object=checklist_obj,
-            data=checklist_obj["record"]["data"],
-            user=self.context["request"].user,
-        )
-        return factory(Checklist, checklist["record"]["data"])

--- a/backend/src/zac/contrib/objects/checklists/api/serializers.py
+++ b/backend/src/zac/contrib/objects/checklists/api/serializers.py
@@ -248,7 +248,12 @@ class ChecklistSerializer(APIModelSerializer):
         return factory(Checklist, self.validated_data)
 
     def update(self) -> Checklist:
-        data = {**self.initial_data, "zaak": self.context["zaak"].url, "meta": True}
+        data = {
+            **self.initial_data,
+            "zaak": self.context["zaak"].url,
+            "meta": True,
+            "lockedBy": None,
+        }  # unlock the checklist at update
         checklist_obj = self.context["checklist_object"]
         update_object_record_data(
             object=checklist_obj,

--- a/backend/src/zac/contrib/objects/checklists/api/urls.py
+++ b/backend/src/zac/contrib/objects/checklists/api/urls.py
@@ -2,7 +2,12 @@ from django.urls import path
 
 from rest_framework.routers import DefaultRouter
 
-from .views import ZaakChecklistTypeView, ZaakChecklistView
+from .views import (
+    LockZaakChecklistView,
+    UnlockZaakChecklistView,
+    ZaakChecklistTypeView,
+    ZaakChecklistView,
+)
 
 router = DefaultRouter(trailing_slash=False)
 
@@ -17,5 +22,15 @@ urlpatterns += [
         "zaak-checklists/<str:bronorganisatie>/<str:identificatie>",
         ZaakChecklistView.as_view(),
         name="zaak-checklist",
+    ),
+    path(
+        "zaak-checklists/<str:bronorganisatie>/<str:identificatie>/lock",
+        LockZaakChecklistView.as_view(),
+        name="lock-zaak-checklist",
+    ),
+    path(
+        "zaak-checklists/<str:bronorganisatie>/<str:identificatie>/unlock",
+        UnlockZaakChecklistView.as_view(),
+        name="unlock-zaak-checklist",
     ),
 ]

--- a/backend/src/zac/contrib/objects/checklists/api/views.py
+++ b/backend/src/zac/contrib/objects/checklists/api/views.py
@@ -23,7 +23,7 @@ from .permission_loaders import add_permissions_for_checklist_assignee
 from .permissions import (
     CanReadOrWriteChecklistsPermission,
     CanReadZaakChecklistTypePermission,
-    ChecklistIsUnlockedOrLockedByCurrentUser,
+    ChecklistIsLockedByCurrentUser,
 )
 from .serializers import ChecklistSerializer, ChecklistTypeSerializer
 
@@ -102,7 +102,7 @@ class BaseZaakChecklistView(views.APIView):
     permission_classes = [
         permissions.IsAuthenticated,
         CanReadOrWriteChecklistsPermission,
-        ChecklistIsUnlockedOrLockedByCurrentUser,
+        ChecklistIsLockedByCurrentUser,
         CanForceEditClosedZaken,
     ]
     serializer_class = ChecklistSerializer

--- a/backend/src/zac/contrib/objects/checklists/data.py
+++ b/backend/src/zac/contrib/objects/checklists/data.py
@@ -15,13 +15,14 @@ class ChecklistAnswer(Model):
     answer: str
     remarks: Optional[str] = ""
     document: Optional[str] = ""
-    user_assignee: Optional[User] = None
-    group_assignee: Optional[Group] = None
+    user_assignee: Optional[str] = None
+    group_assignee: Optional[str] = None
 
 
 @dataclass
 class Checklist(Model):
     answers: List[ChecklistAnswer]
+    locked_by: Optional[str] = None
 
 
 @dataclass

--- a/backend/src/zac/contrib/objects/checklists/tests/test_checklist_permissions.py
+++ b/backend/src/zac/contrib/objects/checklists/tests/test_checklist_permissions.py
@@ -242,6 +242,10 @@ class CreateChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
                 "version": 1,
             },
         )
+        cls.patch_fetch_checklist_object_views = patch(
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=None,
+        )
         cls.patch_fetch_checklist = patch(
             "zac.contrib.objects.checklists.api.serializers.fetch_checklist",
             return_value=None,
@@ -268,6 +272,9 @@ class CreateChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
 
         self.patch_fetch_checklist.start()
         self.addCleanup(self.patch_fetch_checklist.stop)
+
+        self.patch_fetch_checklist_object_views.start()
+        self.addCleanup(self.patch_fetch_checklist_object_views.stop)
 
         self.patch_create_object.start()
         self.addCleanup(self.patch_create_object.stop)
@@ -507,6 +514,14 @@ class UpdatePermissionTests(ESMixin, ClearCachesMixin, APITestCase):
         "zaak-checklist",
         kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
     )
+    lock_endpoint = reverse_lazy(
+        "lock-zaak-checklist",
+        kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+    )
+    unlock_endpoint = reverse_lazy(
+        "unlock-zaak-checklist",
+        kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+    )
 
     @classmethod
     def setUpTestData(cls):
@@ -612,8 +627,18 @@ class UpdatePermissionTests(ESMixin, ClearCachesMixin, APITestCase):
         self.addCleanup(self.patch_update_object_record_data.stop)
 
     def test_update_checklist_not_logged_in(self, m):
-        response = self.client.patch(self.endpoint, {})
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("PUT"):
+            response = self.client.put(self.endpoint, {})
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("POST LOCK"):
+            response = self.client.post(self.lock_endpoint)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("POST UNLOCK"):
+            response = self.client.post(self.unlock_endpoint)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_checklist_logged_in_no_permission(self, m):
         mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
@@ -627,8 +652,17 @@ class UpdatePermissionTests(ESMixin, ClearCachesMixin, APITestCase):
         mock_resource_get(m, self.zaak)
 
         self.client.force_authenticate(user=self.user)
-        response = self.client.put(self.endpoint, {})
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        with self.subTest("PUT"):
+            response = self.client.put(self.endpoint, {})
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("POST LOCK"):
+            response = self.client.post(self.lock_endpoint)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("POST UNLOCK"):
+            response = self.client.post(self.unlock_endpoint)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_checklist_logged_in_with_permissions_for_other_zaak(self, m):
         mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
@@ -821,3 +855,433 @@ class UpdatePermissionTests(ESMixin, ClearCachesMixin, APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.put(self.endpoint, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_checklist_logged_in_with_both_atomic_permissions_but_checklist_is_locked(
+        self, m
+    ):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.zaak)
+
+        data = {
+            "answers": [
+                {
+                    "question": self.checklisttype.questions[0].question,
+                    "answer": "some-answer",
+                }
+            ],
+        }
+        AtomicPermissionFactory.create(
+            permission=checklists_schrijven.name,
+            for_user=self.user,
+            object_url=self.zaak["url"],
+        )
+        AtomicPermissionFactory.create(
+            permission=zaken_geforceerd_bijwerken.name,
+            for_user=self.user,
+            object_url=self.zaak["url"],
+        )
+        self.client.force_authenticate(user=self.user)
+        # create some-other-user
+        user = UserFactory.create(username="some-other-user")
+        checklist_object = deepcopy(CHECKLIST_OBJECT)
+        checklist_object["record"]["data"]["lockedBy"] = "some-other-user"
+
+        with patch(
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=checklist_object,
+        ):
+            response = self.client.put(self.endpoint, data)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.json(),
+            {"detail": f"Checklist is currently locked by `some-other-user`."},
+        )
+
+
+@requests_mock.Mocker()
+class LockChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
+    lock_endpoint = reverse_lazy(
+        "lock-zaak-checklist",
+        kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+    )
+    unlock_endpoint = reverse_lazy(
+        "unlock-zaak-checklist",
+        kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        Service.objects.create(
+            label="Zaken API", api_type=APITypes.zrc, api_root=ZAKEN_ROOT
+        )
+        Service.objects.create(
+            label="Catalogi API",
+            api_type=APITypes.ztc,
+            api_root=CATALOGI_ROOT,
+        )
+
+        cls.catalogus = generate_oas_component(
+            "ztc",
+            "schemas/Catalogus",
+            url=f"{CATALOGI_ROOT}/catalogussen/e13e72de-56ba-42b6-be36-5c280e9b30cd",
+            domein="UTRE",
+        )
+        cls.zaaktype = generate_oas_component(
+            "ztc",
+            "schemas/ZaakType",
+            catalogus=cls.catalogus["url"],
+            url=f"{CATALOGI_ROOT}zaaktypen/d66790b7-8b01-4005-a4ba-8fcf2a60f21d",
+            identificatie="ZT1",
+            omschrijving="ZT1",
+        )
+        cls.zaak = generate_oas_component(
+            "zrc",
+            "schemas/Zaak",
+            url=ZAAK_URL,
+            zaaktype=cls.zaaktype["url"],
+            bronorganisatie=BRONORGANISATIE,
+            identificatie=IDENTIFICATIE,
+        )
+        cls.user = UserFactory.create()
+        data = deepcopy(CHECKLIST_OBJECT)
+        data["record"]["data"]["zaak"] = cls.zaak["url"]
+        cls.patch_update_object_record_data = patch(
+            "zac.contrib.objects.checklists.api.views.update_object_record_data",
+            return_value=None,
+        )
+        cls.lock_checklist_object = deepcopy(CHECKLIST_OBJECT)
+        cls.unlock_checklist_object = deepcopy(CHECKLIST_OBJECT)
+        cls.unlock_checklist_object["record"]["data"]["lockedBy"] = cls.user.username
+
+    def setUp(self):
+        super().setUp()
+        self.patch_update_object_record_data.start()
+        self.addCleanup(self.patch_update_object_record_data.stop)
+
+    def test_un_lock_checklist_not_logged_in(self, m):
+
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_lock_checklist_logged_in_no_permission(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.zaak)
+
+        self.client.force_authenticate(user=self.user)
+
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_lock_checklist_logged_in_with_permissions_for_other_zaak(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.zaak)
+
+        BlueprintPermissionFactory.create(
+            role__permissions=[checklists_schrijven.name],
+            for_user=self.user,
+            policy={
+                "catalogus": self.catalogus["url"],
+                "zaaktype_omschrijving": "ZT2",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        self.client.force_authenticate(user=self.user)
+
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_lock_checklist_logged_in_with_permissions(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.zaak)
+
+        BlueprintPermissionFactory.create(
+            role__permissions=[checklists_schrijven.name],
+            for_user=self.user,
+            policy={
+                "catalogus": self.catalogus["url"],
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        self.client.force_authenticate(user=self.user)
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_lock_checklist_logged_in_with_no_force_permission_closed_zaak(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([{**self.zaak, "einddatum": "2020-01-01"}]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        m.get(self.zaak["url"], json={**self.zaak, "einddatum": "2020-01-01"})
+        BlueprintPermissionFactory.create(
+            role__permissions=[checklists_schrijven.name],
+            for_user=self.user,
+            policy={
+                "catalogus": self.catalogus["url"],
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        self.client.force_authenticate(user=self.user)
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_lock_checklist_logged_in_with_force_permission_closed_zaak(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([{**self.zaak, "einddatum": "2020-01-01"}]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        m.get(self.zaak["url"], json={**self.zaak, "einddatum": "2020-01-01"})
+
+        BlueprintPermissionFactory.create(
+            role__permissions=[checklists_schrijven.name],
+            for_user=self.user,
+            policy={
+                "catalogus": self.catalogus["url"],
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        BlueprintPermissionFactory.create(
+            role__permissions=[zaken_geforceerd_bijwerken.name],
+            for_user=self.user,
+            policy={
+                "catalogus": self.catalogus["url"],
+                "zaaktype_omschrijving": "ZT1",
+                "max_va": VertrouwelijkheidsAanduidingen.zeer_geheim,
+            },
+        )
+        self.client.force_authenticate(user=self.user)
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_lock_checklist_logged_in_with_insufficient_atomic_permission_closed_zaak(
+        self, m
+    ):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([{**self.zaak, "einddatum": "2020-01-01"}]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        m.get(self.zaak["url"], json={**self.zaak, "einddatum": "2020-01-01"})
+        AtomicPermissionFactory.create(
+            permission=checklists_schrijven.name,
+            for_user=self.user,
+            object_url=self.zaak["url"],
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(self.lock_endpoint)
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_lock_checklist_logged_in_with_both_atomic_permissions(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.zaak)
+        AtomicPermissionFactory.create(
+            permission=checklists_schrijven.name,
+            for_user=self.user,
+            object_url=self.zaak["url"],
+        )
+        AtomicPermissionFactory.create(
+            permission=zaken_geforceerd_bijwerken.name,
+            for_user=self.user,
+            object_url=self.zaak["url"],
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(self.lock_endpoint)
+        with self.subTest("LOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.lock_checklist_object,
+            ):
+                response = self.client.post(self.lock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        with self.subTest("UNLOCK"):
+            with patch(
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=self.unlock_checklist_object,
+            ):
+                response = self.client.post(self.unlock_endpoint)
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_lock_checklist_logged_in_with_permissions_but_checklist_is_already_locked_by_someone_else(
+        self, m
+    ):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.zaak)
+
+        AtomicPermissionFactory.create(
+            permission=checklists_schrijven.name,
+            for_user=self.user,
+            object_url=self.zaak["url"],
+        )
+        AtomicPermissionFactory.create(
+            permission=zaken_geforceerd_bijwerken.name,
+            for_user=self.user,
+            object_url=self.zaak["url"],
+        )
+        self.client.force_authenticate(user=self.user)
+        # create some-other-user
+        user = UserFactory.create(username="some-other-user")
+        checklist_object = deepcopy(CHECKLIST_OBJECT)
+        checklist_object["record"]["data"]["lockedBy"] = "some-other-user"
+
+        with patch(
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=checklist_object,
+        ):
+            response = self.client.post(self.lock_endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.json(),
+            {"detail": f"Checklist is currently locked by `some-other-user`."},
+        )

--- a/backend/src/zac/contrib/objects/checklists/tests/test_checklist_response.py
+++ b/backend/src/zac/contrib/objects/checklists/tests/test_checklist_response.py
@@ -397,18 +397,14 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
         self.client.force_authenticate(user=self.user)
         # Put checklist
         with patch(
-            "zac.contrib.objects.checklists.api.serializers.fetch_checklist_object",
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
             return_value=CHECKLIST_OBJECT,
         ):
             with patch(
-                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
-                return_value=CHECKLIST_OBJECT,
+                "zac.contrib.objects.services.fetch_checklisttype_object",
+                return_value=[CHECKLISTTYPE_OBJECT],
             ):
-                with patch(
-                    "zac.contrib.objects.services.fetch_checklisttype_object",
-                    return_value=[CHECKLISTTYPE_OBJECT],
-                ):
-                    response = self.client.put(self.endpoint, data=data)
+                response = self.client.put(self.endpoint, data=data)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -435,3 +431,123 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
                 "lockedBy": None,
             },
         )
+
+    def test_lock_checklist(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        mock_service_oas_get(m, OBJECTS_ROOT, "objects")
+        mock_service_oas_get(m, OBJECTTYPES_ROOT, "objecttypes")
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.catalogus)
+
+        m.patch(
+            f"{OBJECTS_ROOT}objects/{CHECKLIST_OBJECT['uuid']}",
+            json=CHECKLIST_OBJECT,
+            status_code=200,
+        )
+        self.client.force_authenticate(user=self.user)
+        lock_endpoint = reverse_lazy(
+            "lock-zaak-checklist",
+            kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+        )
+
+        with patch(
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=deepcopy(CHECKLIST_OBJECT),
+        ):
+            response = self.client.post(lock_endpoint)
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_lock_checklist_but_already_locked(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        mock_service_oas_get(m, OBJECTS_ROOT, "objects")
+        mock_service_oas_get(m, OBJECTTYPES_ROOT, "objecttypes")
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.catalogus)
+
+        self.client.force_authenticate(user=self.user)
+        lock_endpoint = reverse_lazy(
+            "lock-zaak-checklist",
+            kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+        )
+        checklist_object = deepcopy(CHECKLIST_OBJECT)
+        checklist_object["record"]["data"]["lockedBy"] = self.user.username
+        with patch(
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=checklist_object,
+        ):
+            response = self.client.post(lock_endpoint)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), ["Checklist is already locked."])
+
+    def test_unlock_checklist(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        mock_service_oas_get(m, OBJECTS_ROOT, "objects")
+        mock_service_oas_get(m, OBJECTTYPES_ROOT, "objecttypes")
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.catalogus)
+
+        m.patch(
+            f"{OBJECTS_ROOT}objects/{CHECKLIST_OBJECT['uuid']}",
+            json=CHECKLIST_OBJECT,
+            status_code=200,
+        )
+        self.client.force_authenticate(user=self.user)
+        unlock_endpoint = reverse_lazy(
+            "unlock-zaak-checklist",
+            kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+        )
+        checklist_object = deepcopy(CHECKLIST_OBJECT)
+        checklist_object["record"]["data"]["lockedBy"] = self.user.username
+        with patch(
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=checklist_object,
+        ):
+            response = self.client.post(unlock_endpoint)
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_unlock_checklist_but_checklist_is_not_locked(self, m):
+        mock_service_oas_get(m, ZAKEN_ROOT, "zrc")
+        mock_service_oas_get(m, CATALOGI_ROOT, "ztc")
+        mock_service_oas_get(m, OBJECTS_ROOT, "objects")
+        mock_service_oas_get(m, OBJECTTYPES_ROOT, "objecttypes")
+        m.get(
+            f"{ZAKEN_ROOT}zaken?bronorganisatie=123456789&identificatie=ZAAK-0000001",
+            json=paginated_response([self.zaak]),
+        )
+        mock_resource_get(m, self.zaak)
+        mock_resource_get(m, self.zaaktype)
+        mock_resource_get(m, self.catalogus)
+
+        self.client.force_authenticate(user=self.user)
+        unlock_endpoint = reverse_lazy(
+            "unlock-zaak-checklist",
+            kwargs={"bronorganisatie": BRONORGANISATIE, "identificatie": IDENTIFICATIE},
+        )
+        with patch(
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=CHECKLIST_OBJECT,
+        ):
+            response = self.client.post(unlock_endpoint)
+
+        self.assertEqual(response.status_code, 400)

--- a/backend/src/zac/contrib/objects/checklists/tests/test_checklist_response.py
+++ b/backend/src/zac/contrib/objects/checklists/tests/test_checklist_response.py
@@ -105,7 +105,7 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
         self.client.force_authenticate(user=self.user)
 
         with patch(
-            "zac.contrib.objects.services.fetch_checklist_object",
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
             return_value=CHECKLIST_OBJECT,
         ):
             with patch(
@@ -129,7 +129,8 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
         self.client.force_authenticate(user=self.user)
 
         with patch(
-            "zac.contrib.objects.services.fetch_checklist_object", return_value=[]
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+            return_value=[],
         ):
             response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, 404)
@@ -168,10 +169,15 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
             return_value=[CHECKLISTTYPE_OBJECT],
         ):
             with patch(
-                "zac.contrib.objects.services.fetch_checklist_object",
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
                 return_value=[],
             ):
-                response = self.client.post(self.endpoint, data=data)
+
+                with patch(
+                    "zac.contrib.objects.checklists.api.serializers.fetch_checklist",
+                    return_value=None,
+                ):
+                    response = self.client.post(self.endpoint, data=data)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(
@@ -179,22 +185,23 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
             {
                 "answers": [
                     {
+                        "question": "Ja?",
                         "answer": "",
+                        "remarks": "",
                         "document": "",
                         "groupAssignee": None,
-                        "question": "Ja?",
-                        "remarks": "",
                         "userAssignee": None,
                     },
                     {
+                        "question": "Nee?",
                         "answer": "",
+                        "remarks": "",
                         "document": "",
                         "groupAssignee": None,
-                        "question": "Nee?",
-                        "remarks": "",
                         "userAssignee": None,
                     },
-                ]
+                ],
+                "lockedBy": None,
             },
         )
 
@@ -394,7 +401,7 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
             return_value=CHECKLIST_OBJECT,
         ):
             with patch(
-                "zac.contrib.objects.services.fetch_checklist_object",
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
                 return_value=CHECKLIST_OBJECT,
             ):
                 with patch(
@@ -424,6 +431,7 @@ class ApiResponseTests(ESMixin, ClearCachesMixin, APITestCase):
                         "groupAssignee": None,
                         "userAssignee": None,
                     },
-                ]
+                ],
+                "lockedBy": None,
             },
         )

--- a/backend/src/zac/contrib/objects/checklists/tests/test_grant_permissions_to_assignee.py
+++ b/backend/src/zac/contrib/objects/checklists/tests/test_grant_permissions_to_assignee.py
@@ -303,18 +303,14 @@ class GrantChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
         self.client.force_authenticate(user=self.user)
 
         with patch(
-            "zac.contrib.objects.checklists.api.serializers.fetch_checklist_object",
+            "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
             return_value=CHECKLIST_OBJECT,
         ):
             with patch(
-                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
-                return_value=CHECKLIST_OBJECT,
+                "zac.contrib.objects.services.fetch_checklisttype_object",
+                return_value=[CHECKLISTTYPE_OBJECT],
             ):
-                with patch(
-                    "zac.contrib.objects.services.fetch_checklisttype_object",
-                    return_value=[CHECKLISTTYPE_OBJECT],
-                ):
-                    response = self.client.put(self.endpoint, data=data)
+                response = self.client.put(self.endpoint, data=data)
 
         self.assertEqual(response.status_code, 200)
 

--- a/backend/src/zac/contrib/objects/checklists/tests/test_grant_permissions_to_assignee.py
+++ b/backend/src/zac/contrib/objects/checklists/tests/test_grant_permissions_to_assignee.py
@@ -134,10 +134,14 @@ class GrantChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
             return_value=[CHECKLISTTYPE_OBJECT],
         ):
             with patch(
-                "zac.contrib.objects.services.fetch_checklist_object",
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
                 return_value=[],
             ):
-                response = self.client.post(self.endpoint, data=data)
+                with patch(
+                    "zac.contrib.objects.checklists.api.serializers.fetch_checklist",
+                    return_value=None,
+                ):
+                    response = self.client.post(self.endpoint, data=data)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(AtomicPermission.objects.count(), 0)
@@ -157,7 +161,6 @@ class GrantChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
         mock_resource_get(m, CHECKLIST_OBJECTTYPE)
         mock_resource_get(m, CHECKLIST_OBJECTTYPE_LATEST_VERSION)
         m.get(f"{OBJECTTYPES_ROOT}objecttypes", json=[CHECKLIST_OBJECTTYPE])
-        m.post(f"{OBJECTS_ROOT}objects", json=CHECKLIST_OBJECT, status_code=201)
         m.post(f"{ZAKEN_ROOT}zaakobjecten", json=[], status_code=201)
         data = {
             "answers": [
@@ -169,6 +172,9 @@ class GrantChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
                 },
             ],
         }
+        created = deepcopy(CHECKLIST_OBJECT)
+        created["record"]["data"]["answers"] = data["answers"]
+        m.post(f"{OBJECTS_ROOT}objects", json=created, status_code=201)
 
         self.assertEqual(AtomicPermission.objects.for_user(self.assignee).count(), 0)
 
@@ -178,10 +184,14 @@ class GrantChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
             return_value=[CHECKLISTTYPE_OBJECT],
         ):
             with patch(
-                "zac.contrib.objects.services.fetch_checklist_object",
-                return_value=[],
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
+                return_value=None,
             ):
-                response = self.client.post(self.endpoint, data=data)
+                with patch(
+                    "zac.contrib.objects.services.fetch_checklist_object",
+                    return_value=None,
+                ):
+                    response = self.client.post(self.endpoint, data=data)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(AtomicPermission.objects.for_user(self.assignee).count(), 3)
@@ -234,10 +244,14 @@ class GrantChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
             return_value=[CHECKLISTTYPE_OBJECT],
         ):
             with patch(
-                "zac.contrib.objects.services.fetch_checklist_object",
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
                 return_value=[],
             ):
-                response = self.client.post(self.endpoint, data=data)
+                with patch(
+                    "zac.contrib.objects.checklists.api.serializers.fetch_checklist",
+                    return_value=None,
+                ):
+                    response = self.client.post(self.endpoint, data=data)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(AtomicPermission.objects.for_user(self.assignee).count(), 3)
@@ -293,7 +307,7 @@ class GrantChecklistPermissionTests(ESMixin, ClearCachesMixin, APITestCase):
             return_value=CHECKLIST_OBJECT,
         ):
             with patch(
-                "zac.contrib.objects.services.fetch_checklist_object",
+                "zac.contrib.objects.checklists.api.views.fetch_checklist_object",
                 return_value=CHECKLIST_OBJECT,
             ):
                 with patch(

--- a/backend/src/zac/contrib/objects/checklists/tests/utils.py
+++ b/backend/src/zac/contrib/objects/checklists/tests/utils.py
@@ -3,7 +3,7 @@ CATALOGI_ROOT = "https://open-zaak.nl/catalogi/api/v1/"
 BRONORGANISATIE = "123456789"
 IDENTIFICATIE = "ZAAK-0000001"
 OBJECTTYPES_ROOT = "http://objecttype.nl/api/v1/"
-OBJECTS_ROOT = "http://object.nl/api/v1/"
+OBJECTS_ROOT = "http://object.nl/api/v2/"
 ZAAK_URL = f"{ZAKEN_ROOT}zaken/30a98ef3-bf35-4287-ac9c-fed048619dd7"
 
 
@@ -160,6 +160,7 @@ CHECKLIST_OBJECT = {
                 {"answer": "Ja", "question": "Ja?"},
                 {"answer": "Nee", "question": "Nee?"},
             ],
+            "lockedBy": None,
         },
         "geometry": "None",
         "startAt": "1999-12-31",

--- a/backend/src/zac/contrib/objects/services.py
+++ b/backend/src/zac/contrib/objects/services.py
@@ -216,8 +216,12 @@ def fetch_checklist_object(
     return None
 
 
-def fetch_checklist(zaak: Zaak) -> Optional[Checklist]:
-    checklist_object_data = fetch_checklist_object(zaak)
+def fetch_checklist(
+    zaak: Zaak, checklist_object_data: Optional[Dict] = None
+) -> Optional[Checklist]:
+    if not checklist_object_data:
+        checklist_object_data = fetch_checklist_object(zaak)
+
     if checklist_object_data:
         from zac.contrib.objects.checklists.api.serializers import ChecklistSerializer
 

--- a/backend/src/zac/contrib/objects/tests/schemas/checklists_objects.yaml
+++ b/backend/src/zac/contrib/objects/tests/schemas/checklists_objects.yaml
@@ -7,9 +7,12 @@ components:
         - answers
         - zaak
         - meta
+        - lockedBy
         properties:
           meta: true
           zaak:
+            type: string
+          lockedBy:
             type: string
           answers:
             type: array

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.html
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.html
@@ -1,6 +1,6 @@
 <div class="card">
   <!-- Loading -->
-  <ng-container *ngIf="!finishedLoadingDocuments && hasChecklist || (isLoading && !hasChecklist)">
+  <ng-container *ngIf="!finishedLoadingDocuments && hasChecklist || (isLoading && !hasChecklist) || isLocking">
     <gu-loading-indicator></gu-loading-indicator>
   </ng-container>
   <!-- End loading -->
@@ -14,6 +14,7 @@
              [isLoading]="isSubmitting"
              [buttonPosition]="'top'"
              [buttonSize]="'small'"
+             [verifyToggle]='true'
              title="Takenlijst"
              tooltip="In de takenlijst kun je aangeven welke taken uitgevoerd zijn in deze zaak. Deze vragen kunnen op elk moment tijdens het proces beantwoord worden. Het is mogelijk om een taak toe te wijzen aan een collega."
              (formIsInEditMode)="onClickEditButton($event)"

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.html
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.html
@@ -16,6 +16,7 @@
              [buttonSize]="'small'"
              title="Takenlijst"
              tooltip="In de takenlijst kun je aangeven welke taken uitgevoerd zijn in deze zaak. Deze vragen kunnen op elk moment tijdens het proces beantwoord worden. Het is mogelijk om een taak toe te wijzen aan een collega."
+             (formIsInEditMode)="onClickEditButton($event)"
              (formSubmit)="onSubmitForm($event)">
     </gu-form>
   </ng-container>

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.ts
@@ -289,6 +289,18 @@ export class ChecklistComponent implements OnInit, OnChanges {
   //
 
   /**
+   * Lock or unlock checlist according to event
+   * @param formIsInEditMode
+   */
+  onClickEditButton(formIsInEditMode) {
+    if (formIsInEditMode) {
+      this.checklistService.lockChecklist(this.zaak.bronorganisatie, this.zaak.identificatie).subscribe(() => {})
+    } else {
+      this.checklistService.unLockChecklist(this.zaak.bronorganisatie, this.zaak.identificatie).subscribe(() => {})
+    }
+  }
+
+  /**
    * Gets called when a checklist form is submitted.
    * @param {Object} answerData
    */

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.ts
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/checklist/checklist.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnChanges, OnInit, Output} from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, ViewChild } from '@angular/core';
 import {FieldConfiguration, FieldsetConfiguration, SnackbarService} from '@gu/components';
 import {
   Checklist,
@@ -16,6 +16,7 @@ import {ChecklistService, DocumentenService, UserService, ZaakService} from '@gu
 import {KetenProcessenService} from '../keten-processen/keten-processen.service';
 import {FormGroup} from '@angular/forms';
 import {HttpErrorResponse} from '@angular/common/http';
+import {FormComponent} from '@gu/components';
 
 
 /**
@@ -31,6 +32,7 @@ import {HttpErrorResponse} from '@angular/common/http';
   templateUrl: './checklist.component.html',
 })
 export class ChecklistComponent implements OnInit, OnChanges {
+  @ViewChild(FormComponent) formComponent: FormComponent;
   /** @type {string} Input to identify the organisation. */
   @Input() zaak: Zaak = null;
 
@@ -40,6 +42,7 @@ export class ChecklistComponent implements OnInit, OnChanges {
 
   /** @type {boolean} Whether the API is loading. */
   isLoading = false;
+  isLocking = false;
 
   /** @type {boolean} Whether the form is submitting to the API. */
   isSubmitting = false;
@@ -293,10 +296,28 @@ export class ChecklistComponent implements OnInit, OnChanges {
    * @param formIsInEditMode
    */
   onClickEditButton(formIsInEditMode) {
-    if (formIsInEditMode) {
-      this.checklistService.lockChecklist(this.zaak.bronorganisatie, this.zaak.identificatie).subscribe(() => {})
+    this.isLocking = true;
+    if (!formIsInEditMode) {
+      this.isLocking = true
+      this.checklistService.lockChecklist(this.zaak.bronorganisatie, this.zaak.identificatie).subscribe(() =>
+        {
+          this.formComponent.switchToggle();
+          this.isLocking = false;
+        },
+        error => {
+          this.reportError(error);
+        }
+      )
     } else {
-      this.checklistService.unLockChecklist(this.zaak.bronorganisatie, this.zaak.identificatie).subscribe(() => {})
+      this.checklistService.unLockChecklist(this.zaak.bronorganisatie, this.zaak.identificatie).subscribe(() =>
+        {
+          this.formComponent.switchToggle();
+          this.isLocking = false;
+        },
+        error => {
+          this.reportError(error);
+        }
+      )
     }
   }
 
@@ -376,12 +397,18 @@ export class ChecklistComponent implements OnInit, OnChanges {
    * @param {*} error
    */
   reportError(error: any): void {
-    const message = error.error?.value
+    let message =
+      error.error?.value
       ? error.error?.value[0]
       : error?.error?.detail || error?.error.reason || error?.error[0]?.reason || error?.error.nonFieldErrors?.join(', ') || this.errorMessage;
+    if (error.status === 400) {
+      message = error.error ? error.error[0] : this.errorMessage;
+      this.formComponent.switchToggle();
+    }
     this.snackbarService.openSnackBar(message, 'Sluiten', 'warn');
     this.isLoading = false;
     this.isSubmitting = false;
+    this.isLocking = false;
     console.error(error);
   }
 }

--- a/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.component.scss
+++ b/frontend/zac-ui/libs/features/zaak-detail/src/lib/actions/keten-processen/keten-processen.component.scss
@@ -27,7 +27,7 @@
     .taak {
       padding-bottom: 1rem;
       margin-bottom: 1rem;
-      border-bottom: 1px solid $color-border;
+      border-bottom: 1px solid $color-border-input;
     }
   }
   .edit-icon {

--- a/frontend/zac-ui/libs/shared/data-access/services/src/lib/checklists/checklist.service.ts
+++ b/frontend/zac-ui/libs/shared/data-access/services/src/lib/checklists/checklist.service.ts
@@ -57,4 +57,24 @@ export class ChecklistService {
 
     return this.http.Put<Checklist>(endpoint, params);
   }
+
+  /**
+   * Lock checklist.
+   * @param {string} bronorganisatie
+   * @param {string} identificatie
+   */
+  lockChecklist(bronorganisatie: string, identificatie: string){
+    const endpoint = encodeURI(`/api/checklists/zaak-checklists/${bronorganisatie}/${identificatie}/lock`);
+    return this.http.Post<any>(endpoint);
+  }
+
+  /**
+   * Unlock checklist
+   * @param {string} bronorganisatie
+   * @param {string} identificatie
+   */
+  unLockChecklist(bronorganisatie: string, identificatie: string){
+    const endpoint = encodeURI(`/api/checklists/zaak-checklists/${bronorganisatie}/${identificatie}/unlock`);
+    return this.http.Post<any>(endpoint);
+  }
 }

--- a/frontend/zac-ui/libs/shared/ui/components/src/index.ts
+++ b/frontend/zac-ui/libs/shared/ui/components/src/index.ts
@@ -5,7 +5,8 @@ export * from './lib/shared-ui-components.module';
 export * from './lib/components/map/map';
 export * from './lib/components/map/map.component';
 export * from './lib/components/file-upload/file-upload.component';
-export * from './lib/components/form/field'
+export * from './lib/components/form/field';
+export * from './lib/components/form/form.component';
 export * from './lib/components/modal/modal.service';
 
 // Elements

--- a/frontend/zac-ui/libs/shared/ui/components/src/lib/components/form/form.component.ts
+++ b/frontend/zac-ui/libs/shared/ui/components/src/lib/components/form/form.component.ts
@@ -38,6 +38,7 @@ export class FormComponent implements OnInit, OnChanges {
   @Input() buttonPosition: 'bottom' | 'top' = 'bottom';
   @Input() buttonSize: 'small' | 'large' = 'large';
   @Input() editable: boolean | string = true;
+  @Input() verifyToggle = false;
   @Input() title = '';
   @Input() keys?: string[] = null;
   @Input() resetAfterSubmit = false;
@@ -353,9 +354,17 @@ export class FormComponent implements OnInit, OnChanges {
       e.preventDefault();
     }
 
+    this.formIsInEditMode.emit(this.isInEditMode);
+
+    if (!this.verifyToggle) {
+      this.switchToggle();
+    }
+
+  }
+
+  switchToggle() {
     if (this.editable === 'toggle') {
       this.isInEditMode = !this.isInEditMode;
-      this.formIsInEditMode.emit(this.isInEditMode);
       if (!this.isInEditMode) {
         // reset to initial form values when exiting isInEditMode mode
         this.resolvedKeys = this.keys || this.formService.getKeysFromForm(this.form);

--- a/frontend/zac-ui/libs/shared/ui/components/src/lib/components/form/form.component.ts
+++ b/frontend/zac-ui/libs/shared/ui/components/src/lib/components/form/form.component.ts
@@ -52,6 +52,7 @@ export class FormComponent implements OnInit, OnChanges {
 
   @Output() formChange: EventEmitter<any> = new EventEmitter<any>();
   @Output() formSubmit: EventEmitter<any> = new EventEmitter<any>();
+  @Output() formIsInEditMode: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * @type {Object} Documents mapping.
@@ -354,6 +355,7 @@ export class FormComponent implements OnInit, OnChanges {
 
     if (this.editable === 'toggle') {
       this.isInEditMode = !this.isInEditMode;
+      this.formIsInEditMode.emit(this.isInEditMode);
       if (!this.isInEditMode) {
         // reset to initial form values when exiting isInEditMode mode
         this.resolvedKeys = this.keys || this.formService.getKeysFromForm(this.form);


### PR DESCRIPTION
Fixes https://github.com/GemeenteUtrecht/ZGW/issues/2120

Camunda:
Zaak wordt aangemaakt in Camunda -> Checklist wordt ook in Camunda geinitialiseerd als er een checklisttype voor het zaaktype bestaat.

ZAC:
Een checklist bestaat al (dus hoeft niet gemaakt te worden).
Een bewerking vergt eerst POST naar https://zac.cg-intern..../checklist/bronorganisatie/zaakidentificatie/lock URL (geen data)
Daarna een PUT naar https://zac.cg-intern..../checklist/bronorganisatie/zaakidentificatie (met data)
In een succesvolle PUT wordt de checklist lockedBy ook gecleared.

Wat lukt niet:
Een PUT eerst en dan een lock request -> 403
Een lock op een al gelockte resource als jij niet de locker was -> 403
Een unlock als jij niet de locker was -> 403
Een PUT als jij niet de locker was -> 403
